### PR TITLE
NDLA-416: Added new endpoint for copying a learningpath

### DIFF
--- a/src/main/scala/no/ndla/learningpathapi/controller/LearningpathController.scala
+++ b/src/main/scala/no/ndla/learningpathapi/controller/LearningpathController.scala
@@ -164,6 +164,7 @@ trait LearningpathController {
         parameters(
         headerParam[Option[String]]("X-Correlation-ID").description("User supplied correlation-id. May be omitted."),
         headerParam[Option[String]]("app-key").description("Your app-key."),
+        pathParam[String]("path_id").description("The id of the learningpath to copy."),
         bodyParam[NewCopyLearningPath])
         responseMessages(response400, response403, response404, response500))
 
@@ -372,7 +373,7 @@ trait LearningpathController {
       halt(status = 201, headers = Map("Location" -> learningPath.metaUrl), body = learningPath)
     }
 
-    post("/copy/:path_id", operation(copyLearningpath)) {
+    post("/:path_id/copy", operation(copyLearningpath)) {
       val newLearningPath = extract[NewCopyLearningPath](request.body)
       val pathId = long("path_id")
       updateService.newFromExisting(pathId, newLearningPath, usernameFromHeader) match {

--- a/src/main/scala/no/ndla/learningpathapi/model/api/NewCopyLearningPath.scala
+++ b/src/main/scala/no/ndla/learningpathapi/model/api/NewCopyLearningPath.scala
@@ -1,0 +1,22 @@
+/*
+ * Part of NDLA learningpath_api.
+ * Copyright (C) 2016 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.learningpathapi.model.api
+
+import org.scalatra.swagger.annotations._
+import org.scalatra.swagger.runtime.annotations.ApiModelProperty
+
+import scala.annotation.meta.field
+
+@ApiModel(description = "Meta information for a new learningpath based on a copy")
+case class NewCopyLearningPath(@(ApiModelProperty@field)(description = "The titles of the learningpath") title: Seq[Title],
+                               @(ApiModelProperty@field)(description = "The descriptions of the learningpath") description: Seq[Description],
+                               @(ApiModelProperty@field)(description = "Url to cover-photo in NDLA image-api.") coverPhotoMetaUrl: Option[String],
+                               @(ApiModelProperty@field)(description = "The duration of the learningpath in minutes. Must be greater than 0") duration: Option[Int],
+                               @(ApiModelProperty@field)(description = "Searchable tags for the learningpath") tags: Seq[LearningPathTags],
+                               @(ApiModelProperty@field)(description = "Describes the copyright information for the learningpath") copyright: Option[Copyright])

--- a/src/main/scala/no/ndla/learningpathapi/model/api/NewLearningPath.scala
+++ b/src/main/scala/no/ndla/learningpathapi/model/api/NewLearningPath.scala
@@ -8,8 +8,6 @@
 
 package no.ndla.learningpathapi.model.api
 
-import no.ndla.learningpathapi.model.domain.ValidationException
-import no.ndla.learningpathapi.validation.LearningPathValidator
 import org.scalatra.swagger.annotations._
 import org.scalatra.swagger.runtime.annotations.ApiModelProperty
 

--- a/src/main/scala/no/ndla/learningpathapi/service/UpdateServiceComponent.scala
+++ b/src/main/scala/no/ndla/learningpathapi/service/UpdateServiceComponent.scala
@@ -21,7 +21,7 @@ trait UpdateServiceComponent {
   val updateService: UpdateService
 
   class UpdateService {
-    def newFromExisting(id: Long, newLearningPath: NewLearningPath, owner: String): Option[LearningPath] = {
+    def newFromExisting(id: Long, newLearningPath: NewCopyLearningPath, owner: String): Option[LearningPath] = {
       learningPathRepository.withId(id) match {
         case None => None
         case Some(existing) => {
@@ -32,7 +32,7 @@ trait UpdateServiceComponent {
           val tags = if(newLearningPath.tags.nonEmpty) newLearningPath.tags.map(converterService.asLearningPathTags) else existing.tags
           val coverPhotoMetaUrl = if(newLearningPath.coverPhotoMetaUrl.nonEmpty) newLearningPath.coverPhotoMetaUrl else existing.coverPhotoMetaUrl
           val duration = if(newLearningPath.duration.nonEmpty) newLearningPath.duration else existing.duration
-          val copyright = converterService.asCopyright(newLearningPath.copyright)
+          val copyright = newLearningPath.copyright.map(converterService.asCopyright).getOrElse(existing.copyright)
 
           val toInsert = existing.copy(
             id = None,

--- a/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
+++ b/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
@@ -49,7 +49,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
   val PRIVATE_LEARNINGPATH = domain.LearningPath(Some(PRIVATE_ID), Some(1), None, None, List(Title("Tittel", Some("nb"))), List(Description("Beskrivelse", Some("nb"))), None, Some(1), domain.LearningPathStatus.PRIVATE, LearningPathVerificationStatus.EXTERNAL, new Date(), List(), PRIVATE_OWNER, copyright, STEP1 :: STEP2 :: STEP3 :: STEP4 :: STEP5 :: STEP6 :: Nil)
   val NEW_PRIVATE_LEARNINGPATH = NewLearningPath(List(api.Title("Tittel", Some("nb"))), List(api.Description("Beskrivelse", Some("nb"))), None, Some(1), List(), apiCopyright)
   val NEW_PUBLISHED_LEARNINGPATH = NewLearningPath(List(), List(), None, Some(1), List(), apiCopyright)
-  val NEW_COPY_LEARNINGPATH = NewCopyLearningPath(List(api.Title("Tittel", Some("nb"))), List(api.Description("Beskrivelse", Some("nb"))), None, Some(1), List(), None)
+  val NEW_COPIED_LEARNINGPATH = NewCopyLearningPath(List(api.Title("Tittel", Some("nb"))), List(api.Description("Beskrivelse", Some("nb"))), None, Some(1), List(), None)
 
   val UPDATED_PRIVATE_LEARNINGPATH = UpdatedLearningPath(1, List(), List(), None, Some(1), List(), apiCopyright)
   val UPDATED_PUBLISHED_LEARNINGPATH = UpdatedLearningPath(1, List(), List(), None, Some(1), List(), apiCopyright)
@@ -500,14 +500,14 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
 
     assertResult("You do not have access to the requested resource."){
       intercept[AccessDeniedException] {
-        service.newFromExisting(PRIVATE_ID, NEW_COPY_LEARNINGPATH, PUBLISHED_OWNER)
+        service.newFromExisting(PRIVATE_ID, NEW_COPIED_LEARNINGPATH, PUBLISHED_OWNER)
       }.getMessage
     }
   }
 
   test("That newFromExisting returns None when given id does not exist") {
     when(learningPathRepository.withId(PUBLISHED_ID)).thenReturn(None)
-    service.newFromExisting(PUBLISHED_ID, NEW_COPY_LEARNINGPATH, PUBLISHED_OWNER) should be (None)
+    service.newFromExisting(PUBLISHED_ID, NEW_COPIED_LEARNINGPATH, PUBLISHED_OWNER) should be (None)
   }
 
   test("That basic-information unique per learningpath is reset in newFromExisting") {
@@ -518,7 +518,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     when(learningPathRepository.insert(any[domain.LearningPath])(any[DBSession])).thenReturn(PUBLISHED_LEARNINGPATH_NO_STEPS)
     when(mappingApiClient.getLicense("publicdomain")).thenReturn(Some(License("publicdomain", Some("description"), Some("www.vg.no"))))
 
-    service.newFromExisting(PUBLISHED_ID, NEW_COPY_LEARNINGPATH, PRIVATE_OWNER)
+    service.newFromExisting(PUBLISHED_ID, NEW_COPIED_LEARNINGPATH, PRIVATE_OWNER)
     val expectedNewLearningPath = PUBLISHED_LEARNINGPATH_NO_STEPS.copy(
       id = None,
       revision = None,
@@ -548,7 +548,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     val durationOverride = Some(100)
 
     service.newFromExisting(PUBLISHED_ID,
-      NEW_COPY_LEARNINGPATH.copy(
+      NEW_COPIED_LEARNINGPATH.copy(
         title = titlesToOverride,
         description = descriptionsToOverride,
         tags = tagsToOverride,
@@ -585,7 +585,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     when(learningPathRepository.insert(any[domain.LearningPath])(any[DBSession])).thenReturn(PUBLISHED_LEARNINGPATH)
     when(mappingApiClient.getLicense("publicdomain")).thenReturn(Some(License("publicdomain", Some("description"), Some("www.vg.no"))))
 
-    service.newFromExisting(PUBLISHED_ID, NEW_COPY_LEARNINGPATH, PRIVATE_OWNER)
+    service.newFromExisting(PUBLISHED_ID, NEW_COPIED_LEARNINGPATH, PRIVATE_OWNER)
 
     val expectedNewLearningPath = PUBLISHED_LEARNINGPATH.copy(
       id = None,

--- a/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
+++ b/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
@@ -12,9 +12,8 @@ import java.util.Date
 
 import no.ndla.learningpathapi._
 import no.ndla.learningpathapi.model._
-import no.ndla.learningpathapi.model.api.{LearningPathStatus, NewLearningPath, NewLearningStep, UpdatedLearningPath, UpdatedLearningStep}
+import no.ndla.learningpathapi.model.api.{License, LearningPathStatus, NewLearningPath, NewLearningStep, UpdatedLearningPath, UpdatedLearningStep, NewCopyLearningPath}
 import no.ndla.learningpathapi.model.domain._
-import no.ndla.learningpathapi.model.api.{License}
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import scalikejdbc.DBSession
@@ -50,6 +49,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
   val PRIVATE_LEARNINGPATH = domain.LearningPath(Some(PRIVATE_ID), Some(1), None, None, List(Title("Tittel", Some("nb"))), List(Description("Beskrivelse", Some("nb"))), None, Some(1), domain.LearningPathStatus.PRIVATE, LearningPathVerificationStatus.EXTERNAL, new Date(), List(), PRIVATE_OWNER, copyright, STEP1 :: STEP2 :: STEP3 :: STEP4 :: STEP5 :: STEP6 :: Nil)
   val NEW_PRIVATE_LEARNINGPATH = NewLearningPath(List(api.Title("Tittel", Some("nb"))), List(api.Description("Beskrivelse", Some("nb"))), None, Some(1), List(), apiCopyright)
   val NEW_PUBLISHED_LEARNINGPATH = NewLearningPath(List(), List(), None, Some(1), List(), apiCopyright)
+  val NEW_COPY_LEARNINGPATH = NewCopyLearningPath(List(api.Title("Tittel", Some("nb"))), List(api.Description("Beskrivelse", Some("nb"))), None, Some(1), List(), None)
 
   val UPDATED_PRIVATE_LEARNINGPATH = UpdatedLearningPath(1, List(), List(), None, Some(1), List(), apiCopyright)
   val UPDATED_PUBLISHED_LEARNINGPATH = UpdatedLearningPath(1, List(), List(), None, Some(1), List(), apiCopyright)
@@ -500,14 +500,14 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
 
     assertResult("You do not have access to the requested resource."){
       intercept[AccessDeniedException] {
-        service.newFromExisting(PRIVATE_ID, NEW_PRIVATE_LEARNINGPATH, PUBLISHED_OWNER)
+        service.newFromExisting(PRIVATE_ID, NEW_COPY_LEARNINGPATH, PUBLISHED_OWNER)
       }.getMessage
     }
   }
 
   test("That newFromExisting returns None when given id does not exist") {
     when(learningPathRepository.withId(PUBLISHED_ID)).thenReturn(None)
-    service.newFromExisting(PUBLISHED_ID, NEW_PRIVATE_LEARNINGPATH, PUBLISHED_OWNER) should be (None)
+    service.newFromExisting(PUBLISHED_ID, NEW_COPY_LEARNINGPATH, PUBLISHED_OWNER) should be (None)
   }
 
   test("That basic-information unique per learningpath is reset in newFromExisting") {
@@ -518,7 +518,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     when(learningPathRepository.insert(any[domain.LearningPath])(any[DBSession])).thenReturn(PUBLISHED_LEARNINGPATH_NO_STEPS)
     when(mappingApiClient.getLicense("publicdomain")).thenReturn(Some(License("publicdomain", Some("description"), Some("www.vg.no"))))
 
-    service.newFromExisting(PUBLISHED_ID, NEW_PRIVATE_LEARNINGPATH, PRIVATE_OWNER)
+    service.newFromExisting(PUBLISHED_ID, NEW_COPY_LEARNINGPATH, PRIVATE_OWNER)
     val expectedNewLearningPath = PUBLISHED_LEARNINGPATH_NO_STEPS.copy(
       id = None,
       revision = None,
@@ -548,7 +548,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     val durationOverride = Some(100)
 
     service.newFromExisting(PUBLISHED_ID,
-      NEW_PRIVATE_LEARNINGPATH.copy(
+      NEW_COPY_LEARNINGPATH.copy(
         title = titlesToOverride,
         description = descriptionsToOverride,
         tags = tagsToOverride,
@@ -585,7 +585,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     when(learningPathRepository.insert(any[domain.LearningPath])(any[DBSession])).thenReturn(PUBLISHED_LEARNINGPATH)
     when(mappingApiClient.getLicense("publicdomain")).thenReturn(Some(License("publicdomain", Some("description"), Some("www.vg.no"))))
 
-    service.newFromExisting(PUBLISHED_ID, NEW_PRIVATE_LEARNINGPATH, PRIVATE_OWNER)
+    service.newFromExisting(PUBLISHED_ID, NEW_COPY_LEARNINGPATH, PRIVATE_OWNER)
 
     val expectedNewLearningPath = PUBLISHED_LEARNINGPATH.copy(
       id = None,


### PR DESCRIPTION
Samme API endepunkt ble tidligere brukt for å både oprette en ny læringssti og kopiere en læringssti. Problemet oppstår når Copyright må være spesifisert for dette endepunktet. Når en helt ny læringssti oprettes skal copyright spesifiseres, mens det skal ikke behøve å være spesifisert når man kopierer; da kan copyright feltet fra stien man kopierer brukes.

Derfor foreslår jeg at kopi-funksjonaliteten flyttes fra "oprett ny sti" endepunktet til et eget "kopi sti" endepunkt.