### PR TITLE
Ndlano/issues#531 fix copy learningpath bug

### DIFF
--- a/src/main/scala/no/ndla/learningpathapi/service/UpdateServiceComponent.scala
+++ b/src/main/scala/no/ndla/learningpathapi/service/UpdateServiceComponent.scala
@@ -49,7 +49,7 @@ trait UpdateServiceComponent {
             tags = tags,
             coverPhotoId = coverPhotoId,
             duration = duration)
-          learningPathValidator.validate(toInsert)
+          learningPathValidator.validate(toInsert, allowUnknownLanguage = true)
           Some(converterService.asApiLearningpath(learningPathRepository.insert(toInsert), Some(owner)))
         }
       }
@@ -94,7 +94,7 @@ trait UpdateServiceComponent {
             tags = tags,
             coverPhotoId = coverPhotoId,
             duration = duration)
-          learningPathValidator.validate(toInsert)
+          learningPathValidator.validate(toInsert, allowUnknownLanguage = true)
           converterService.asApiLearningpathV2(learningPathRepository.insert(toInsert), newLearningPath.language, Some(owner))
         }
       }

--- a/src/main/scala/no/ndla/learningpathapi/validation/LanguageValidator.scala
+++ b/src/main/scala/no/ndla/learningpathapi/validation/LanguageValidator.scala
@@ -9,9 +9,7 @@
 package no.ndla.learningpathapi.validation
 
 import no.ndla.learningpathapi.model.api.ValidationMessage
-import no.ndla.learningpathapi.model.domain.ValidationException
 import no.ndla.mapping.ISO639.get6391CodeFor6392CodeMappings
-import no.ndla.learningpathapi.model.domain.Language
 
 trait LanguageValidator {
   val languageValidator : LanguageValidator
@@ -28,21 +26,6 @@ trait LanguageValidator {
         case false => Some(ValidationMessage(fieldPath, s"Language '$languageCode' is not a supported value."))
       }
     }
-  }
 
-  object LanguageValidator {
-    def validate(fieldPath: String, languageCode: String): String = {
-      languageValidator.validate(fieldPath, languageCode, allowUnknownLanguage=false) match {
-        case Some(validationMessage) => throw new ValidationException(errors = validationMessage :: Nil)
-        case None => languageCode
-      }
-    }
-
-    def checkIfLanguageIsSupported(supportedLanguages: Seq[String], language: String) = {
-      if (!supportedLanguages.contains(language) && language != Language.AllLanguages) {
-        val validationMessage = ValidationMessage("language", s"Language '$language' is not a supported value.")
-        throw new ValidationException(errors = validationMessage :: Nil)
-      }
-    }
   }
 }

--- a/src/main/scala/no/ndla/learningpathapi/validation/LanguageValidator.scala
+++ b/src/main/scala/no/ndla/learningpathapi/validation/LanguageValidator.scala
@@ -17,11 +17,13 @@ trait LanguageValidator {
   val languageValidator : LanguageValidator
 
   class LanguageValidator {
-    private def languageCodeSupported6391(languageCode: String): Boolean =
-      get6391CodeFor6392CodeMappings.exists(_._2 == languageCode)
+    private def languageCodeSupported6391(languageCode: String, allowUnknownLanguage: Boolean): Boolean = {
+      val languageCodes = get6391CodeFor6392CodeMappings.values.toSeq ++ (if (allowUnknownLanguage) Seq("unknown") else Seq.empty)
+      languageCodes.contains(languageCode)
+    }
 
-    def validate(fieldPath: String, languageCode: String): Option[ValidationMessage] = {
-      languageCode.nonEmpty && languageCodeSupported6391(languageCode) match {
+    def validate(fieldPath: String, languageCode: String, allowUnknownLanguage: Boolean): Option[ValidationMessage] = {
+      languageCode.nonEmpty && languageCodeSupported6391(languageCode, allowUnknownLanguage) match {
         case true => None
         case false => Some(ValidationMessage(fieldPath, s"Language '$languageCode' is not a supported value."))
       }
@@ -30,7 +32,7 @@ trait LanguageValidator {
 
   object LanguageValidator {
     def validate(fieldPath: String, languageCode: String): String = {
-      languageValidator.validate(fieldPath, languageCode) match {
+      languageValidator.validate(fieldPath, languageCode, allowUnknownLanguage=false) match {
         case Some(validationMessage) => throw new ValidationException(errors = validationMessage :: Nil)
         case None => languageCode
       }

--- a/src/main/scala/no/ndla/learningpathapi/validation/LearningStepValidator.scala
+++ b/src/main/scala/no/ndla/learningpathapi/validation/LearningStepValidator.scala
@@ -23,35 +23,35 @@ trait LearningStepValidator {
 
     val MISSING_DESCRIPTION_OR_EMBED_URL = "A learningstep is required to have either a description, embedUrl or both."
 
-    def validate(newLearningStep: LearningStep): LearningStep = {
-      validateLearningStep(newLearningStep) match {
+    def validate(newLearningStep: LearningStep, allowUnknownLanguage: Boolean = false): LearningStep = {
+      validateLearningStep(newLearningStep, allowUnknownLanguage) match {
         case head :: tail => throw new ValidationException(errors = head :: tail)
         case _ => newLearningStep
       }
     }
 
-    def validateLearningStep(newLearningStep: LearningStep): Seq[ValidationMessage] = {
-      titleValidator.validate(newLearningStep.title) ++
-        validateDescription(newLearningStep.description) ++
-        validateEmbedUrl(newLearningStep.embedUrl) ++
+    def validateLearningStep(newLearningStep: LearningStep, allowUnknownLanguage: Boolean): Seq[ValidationMessage] = {
+      titleValidator.validate(newLearningStep.title, allowUnknownLanguage) ++
+        validateDescription(newLearningStep.description, allowUnknownLanguage) ++
+        validateEmbedUrl(newLearningStep.embedUrl, allowUnknownLanguage) ++
         validateLicense(newLearningStep.license).toList ++
         validateThatDescriptionOrEmbedUrlOrBothIsDefined(newLearningStep).toList
     }
 
-    def validateDescription(descriptions: Seq[Description]): Seq[ValidationMessage] = {
+    def validateDescription(descriptions: Seq[Description], allowUnknownLanguage: Boolean): Seq[ValidationMessage] = {
       descriptions.isEmpty match {
         case true => List()
         case false => descriptions.flatMap(description => {
           basicHtmlTextValidator.validate("description.description", description.description).toList :::
-            languageValidator.validate("description.language", description.language).toList
+            languageValidator.validate("description.language", description.language, allowUnknownLanguage).toList
         })
       }
     }
 
-    def validateEmbedUrl(embedUrls: Seq[EmbedUrl]): Seq[ValidationMessage] = {
+    def validateEmbedUrl(embedUrls: Seq[EmbedUrl], allowUnknownLanguage: Boolean): Seq[ValidationMessage] = {
       embedUrls.flatMap(embedUrl => {
         urlValidator.validate("embedUrl.url", embedUrl.url).toList :::
-          languageValidator.validate("embedUrl.language", embedUrl.language).toList
+          languageValidator.validate("embedUrl.language", embedUrl.language, allowUnknownLanguage).toList
       })
     }
 

--- a/src/main/scala/no/ndla/learningpathapi/validation/TitleValidator.scala
+++ b/src/main/scala/no/ndla/learningpathapi/validation/TitleValidator.scala
@@ -20,17 +20,17 @@ trait TitleValidator {
 
     val noHtmlTextValidator = new TextValidator(allowHtml = false)
 
-    def validate(titles: Seq[Title]): Seq[ValidationMessage] = {
+    def validate(titles: Seq[Title], allowUnknownLanguage: Boolean): Seq[ValidationMessage] = {
       (titleRequired, titles.isEmpty) match {
         case (false, true) => List()
         case (true, true) => List(ValidationMessage("title", MISSING_TITLE))
-        case (_, false) => titles.flatMap(title => validate(title))
+        case (_, false) => titles.flatMap(title => validate(title, allowUnknownLanguage))
       }
     }
 
-    private def validate(title: Title): Seq[ValidationMessage] = {
+    private def validate(title: Title, allowUnknownLanguage: Boolean): Seq[ValidationMessage] = {
       noHtmlTextValidator.validate("title.title", title.title).toList :::
-        languageValidator.validate("title.language", title.language).toList
+        languageValidator.validate("title.language", title.language, allowUnknownLanguage).toList
     }
   }
 }

--- a/src/test/scala/no/ndla/learningpathapi/controller/LearningpathControllerTest.scala
+++ b/src/test/scala/no/ndla/learningpathapi/controller/LearningpathControllerTest.scala
@@ -32,7 +32,10 @@ class LearningpathControllerTest extends UnitSuite with TestEnvironment with Sca
   lazy val controller = new LearningpathController
   addServlet(controller, "/*")
 
-  override def beforeEach() = resetMocks()
+  override def beforeEach() = {
+    resetMocks()
+    when(languageValidator.validate(any[String], any[String], any[Boolean])).thenReturn(None)
+  }
 
   test("That requireHeader returns header value when header exists") {
     implicit val request:HttpServletRequest = mock[HttpServletRequest]
@@ -65,7 +68,6 @@ class LearningpathControllerTest extends UnitSuite with TestEnvironment with Sca
 
     when(searchService.matchingQuery(eqTo(List(1,2)), eqTo(query), eqTo(Some(tag)), eqTo(Some(language)), eqTo(Sort.ByDurationDesc), eqTo(Some(page)), eqTo(Some(pageSize)))).thenReturn(result)
     when(searchService.getHits(searchResult)).thenReturn(Seq(DefaultLearningPathSummary))
-    when(languageValidator.validate(any[String], any[String])).thenReturn(None)
 
     get("/", Map(
       "query" -> query,
@@ -96,7 +98,6 @@ class LearningpathControllerTest extends UnitSuite with TestEnvironment with Sca
 
     when(searchService.all(any[List[Long]], any[Option[String]], any[Sort.Value], any[Option[String]], any[Option[Int]], any[Option[Int]])).thenReturn(result)
     when(searchService.getHits(searchResult)).thenReturn(Seq(DefaultLearningPathSummary))
-    when(languageValidator.validate(any[String], any[String])).thenReturn(None)
 
     get("/", Map(
       "query" -> query,
@@ -126,7 +127,6 @@ class LearningpathControllerTest extends UnitSuite with TestEnvironment with Sca
 
     when(searchService.matchingQuery(eqTo(List(1,2)), eqTo(query), eqTo(Some(tag)), eqTo(Some(language)), eqTo(Sort.ByDurationDesc), eqTo(Some(page)), eqTo(Some(pageSize)))).thenReturn(result)
     when(searchService.getHits(searchResult)).thenReturn(Seq(DefaultLearningPathSummary))
-    when(languageValidator.validate(any[String], any[String])).thenReturn(None)
 
     post("/search/", body=s"""{"query": "$query", "tag": "$tag", "language": "$language", "page": $page, "pageSize": $pageSize, "ids": [1, 2], "sort": "-duration" }""") {
       status should equal (200)

--- a/src/test/scala/no/ndla/learningpathapi/controller/LearningpathControllerTestV2.scala
+++ b/src/test/scala/no/ndla/learningpathapi/controller/LearningpathControllerTestV2.scala
@@ -32,7 +32,10 @@ class LearningpathControllerTestV2 extends UnitSuite with TestEnvironment with S
   lazy val controller = new LearningpathControllerV2
   addServlet(controller, "/*")
 
-  override def beforeEach() = resetMocks()
+  override def beforeEach() = {
+    resetMocks()
+    when(languageValidator.validate(any[String], any[String], any[Boolean])).thenReturn(None)
+  }
 
   test("That requireHeader returns header value when header exists") {
     implicit val request:HttpServletRequest = mock[HttpServletRequest]
@@ -65,7 +68,6 @@ class LearningpathControllerTestV2 extends UnitSuite with TestEnvironment with S
 
     when(searchService.matchingQuery(eqTo(List(1,2)), eqTo(query), eqTo(Some(tag)), eqTo(Some(language)), eqTo(Sort.ByDurationDesc), eqTo(Some(page)), eqTo(Some(pageSize)))).thenReturn(result)
     when(searchService.getHitsV2(searchResult, language)).thenReturn(Seq(DefaultLearningPathSummary))
-    when(languageValidator.validate(any[String], any[String])).thenReturn(None)
 
     get("/", Map(
       "query" -> query,
@@ -96,7 +98,6 @@ class LearningpathControllerTestV2 extends UnitSuite with TestEnvironment with S
 
     when(searchService.allV2(any[List[Long]], any[Option[String]], any[Sort.Value], any[Option[String]], any[Option[Int]], any[Option[Int]])).thenReturn(result)
     when(searchService.getHitsV2(any[io.searchbox.core.SearchResult], any[String])).thenReturn(Seq(DefaultLearningPathSummary))
-    when(languageValidator.validate(any[String], any[String])).thenReturn(None)
 
     get("/", Map(
       "query" -> query,
@@ -126,7 +127,6 @@ class LearningpathControllerTestV2 extends UnitSuite with TestEnvironment with S
 
     when(searchService.matchingQuery(eqTo(List(1,2)), eqTo(query), eqTo(Some(tag)), eqTo(Some(language)), eqTo(Sort.ByDurationDesc), eqTo(Some(page)), eqTo(Some(pageSize)))).thenReturn(result)
     when(searchService.getHitsV2(any[io.searchbox.core.SearchResult], any[String])).thenReturn(Seq(DefaultLearningPathSummary))
-    when(languageValidator.validate(any[String], any[String])).thenReturn(None)
 
     post("/search/", body=s"""{"query": "$query", "tag": "$tag", "language": "$language", "page": $page, "pageSize": $pageSize, "ids": [1, 2], "sort": "-duration" }""") {
       status should equal (200)

--- a/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
+++ b/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
@@ -12,7 +12,7 @@ import java.util.Date
 
 import no.ndla.learningpathapi._
 import no.ndla.learningpathapi.model._
-import no.ndla.learningpathapi.model.api.{License, NewLearningPathV2, NewLearningPath, NewLearningStep, NewLearningStepV2, UpdatedLearningPath, UpdatedLearningPathV2, UpdatedLearningStep, UpdatedLearningStepV2, NewCopyLearningPath}
+import no.ndla.learningpathapi.model.api.{NewLearningPathV2, NewLearningPath, NewLearningStep, NewLearningStepV2, UpdatedLearningPath, UpdatedLearningPathV2, UpdatedLearningStep, UpdatedLearningStepV2, NewCopyLearningPath, NewCopyLearningPathV2}
 import no.ndla.learningpathapi.model.domain._
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
@@ -606,6 +606,16 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     updatedStep.get.seqNo should equal (1)
 
     verify(learningPathRepository, times(2)).updateLearningStep(any[LearningStep])(any[DBSession])
+  }
+
+  test("new fromExisting2 should allow laugage fields set to unknown") {
+    val learningpathWithUnknownLang = PUBLISHED_LEARNINGPATH.copy(title = Seq(Title("what språk is this", "unknown")))
+
+    when(learningPathRepository.withId(learningpathWithUnknownLang.id.get)).thenReturn(Some(learningpathWithUnknownLang))
+    when(learningPathRepository.insert(any[LearningPath])(any[DBSession])).thenReturn(learningpathWithUnknownLang)
+
+    val newCopy = NewCopyLearningPathV2("hehe", None, "nb", None, None, None, None)
+    service.newFromExistingV2(learningpathWithUnknownLang.id.get, newCopy, "me").isDefined should be (true)
   }
 
   test("That newFromExisting throws exception when user is not owner of the path and the path is private") {

--- a/src/test/scala/no/ndla/learningpathapi/validation/LanguageValidatorTest.scala
+++ b/src/test/scala/no/ndla/learningpathapi/validation/LanguageValidatorTest.scala
@@ -22,18 +22,18 @@ class LanguageValidatorTest extends UnitSuite with TestEnvironment {
   }
 
   test("That LanguageValidator returns no error message for nb") {
-    validator.validate("path1.path2", "nb") should be(None)
+    validator.validate("path1.path2", "nb", false) should be(None)
   }
 
   test("That LanguageValidator returns error for something") {
-    val errorMessage = validator.validate("path1.path2", "something")
+    val errorMessage = validator.validate("path1.path2", "something", false)
     errorMessage.isDefined should be(true)
     errorMessage.get.field should equal("path1.path2")
     errorMessage.get.message should equal("Language 'something' is not a supported value.")
   }
 
   test("That exception is thrown when calling singleton object") {
-    when(languageValidator.validate("language", "error")).thenReturn(Some(ValidationMessage("language", "Language 'error' is not a supported value.")))
+    when(languageValidator.validate("language", "error", false)).thenReturn(Some(ValidationMessage("language", "Language 'error' is not a supported value.")))
 
     assertResult("Language 'error' is not a supported value.") {
       intercept[ValidationException]{
@@ -43,7 +43,7 @@ class LanguageValidatorTest extends UnitSuite with TestEnvironment {
   }
 
   test("That input value is returned when no error") {
-    when(languageValidator.validate("language", "nb")).thenReturn(None)
+    when(languageValidator.validate("language", "nb", false)).thenReturn(None)
     LanguageValidator.validate("language", "nb") should equal ("nb")
   }
 }

--- a/src/test/scala/no/ndla/learningpathapi/validation/LanguageValidatorTest.scala
+++ b/src/test/scala/no/ndla/learningpathapi/validation/LanguageValidatorTest.scala
@@ -9,9 +9,7 @@
 package no.ndla.learningpathapi.validation
 
 import no.ndla.learningpathapi.{TestEnvironment, UnitSuite}
-import no.ndla.learningpathapi.model.api.{ValidationMessage, ValidationError}
-import no.ndla.learningpathapi.model.domain.ValidationException
-import org.mockito.Mockito._
+
 class LanguageValidatorTest extends UnitSuite with TestEnvironment {
 
   var validator: LanguageValidator = _
@@ -32,18 +30,4 @@ class LanguageValidatorTest extends UnitSuite with TestEnvironment {
     errorMessage.get.message should equal("Language 'something' is not a supported value.")
   }
 
-  test("That exception is thrown when calling singleton object") {
-    when(languageValidator.validate("language", "error", false)).thenReturn(Some(ValidationMessage("language", "Language 'error' is not a supported value.")))
-
-    assertResult("Language 'error' is not a supported value.") {
-      intercept[ValidationException]{
-        LanguageValidator.validate("language", "error")
-      }.errors.head.message
-    }
-  }
-
-  test("That input value is returned when no error") {
-    when(languageValidator.validate("language", "nb", false)).thenReturn(None)
-    LanguageValidator.validate("language", "nb") should equal ("nb")
-  }
 }

--- a/src/test/scala/no/ndla/learningpathapi/validation/LearningPathValidatorTest.scala
+++ b/src/test/scala/no/ndla/learningpathapi/validation/LearningPathValidatorTest.scala
@@ -46,21 +46,19 @@ class LearningPathValidatorTest extends UnitSuite with Clock with TestEnvironmen
     copyright = copyright)
 
   private def validMock() = {
-    when(languageValidator.validate("description.language", "nb")).thenReturn(None)
-    when(titleValidator.validate(ValidLearningPath.title)).thenReturn(List())
-    when(languageValidator.validate("tags.language", "nb")).thenReturn(None)
+    when(languageValidator.validate("description.language", "nb", false)).thenReturn(None)
+    when(titleValidator.validate(ValidLearningPath.title, false)).thenReturn(List())
+    when(languageValidator.validate("tags.language", "nb", false)).thenReturn(None)
   }
 
   test("That valid learningpath returns no errors") {
     validMock()
-    validator.validateLearningPath(ValidLearningPath) should equal (List())
+    validator.validateLearningPath(ValidLearningPath, allowUnknownLanguage=false) should equal (List())
   }
 
   test("That validate returns no error for no coverPhoto") {
     validMock()
-    validator.validateLearningPath(ValidLearningPath.copy(
-      coverPhotoId = None
-    )) should be(List())
+    validator.validateLearningPath(ValidLearningPath.copy(coverPhotoId=None), allowUnknownLanguage=false) should be(List())
   }
 
   test("That validateCoverPhoto returns an error when metaUrl is pointing to some another api on ndla") {
@@ -90,7 +88,7 @@ class LearningPathValidatorTest extends UnitSuite with Clock with TestEnvironmen
 
   test("That validate returns error message when no descriptions are defined") {
     validMock()
-    val errorMessages = validator.validateLearningPath(ValidLearningPath.copy(description = List()))
+    val errorMessages = validator.validateLearningPath(ValidLearningPath.copy(description = List()), allowUnknownLanguage = false)
     errorMessages.size should be (1)
     errorMessages.head.field should equal("description")
     errorMessages.head.message should equal("At least one description is required.")
@@ -98,48 +96,49 @@ class LearningPathValidatorTest extends UnitSuite with Clock with TestEnvironmen
 
   test("That validate does not return error message when no descriptions are defined and no descriptions are required") {
     validMock()
-    new LearningPathValidator(descriptionRequired = false).validateLearningPath(ValidLearningPath.copy(description = List())) should equal (List())
+    new LearningPathValidator(descriptionRequired = false)
+      .validateLearningPath(ValidLearningPath.copy(description = List()), allowUnknownLanguage = false) should equal (List())
   }
 
   test("That validate returns error message when description contains html") {
     validMock()
-    val validationErrors = validator.validateLearningPath(ValidLearningPath.copy(description = List(Description("<h1>Ugyldig</h1>", "nb"))))
+    val validationErrors = validator.validateLearningPath(ValidLearningPath.copy(description = List(Description("<h1>Ugyldig</h1>", "nb"))), false)
     validationErrors.size should be (1)
     validationErrors.head.field should equal("description.description")
   }
   test("That validate returns error when description has an illegal language") {
-    when(languageValidator.validate("description.language", "bergensk")).thenReturn(Some(ValidationMessage("description.language", "Error")))
-    when(titleValidator.validate(ValidLearningPath.title)).thenReturn(List())
-    when(languageValidator.validate("tags.language", "nb")).thenReturn(None)
+    when(languageValidator.validate("description.language", "bergensk", false)).thenReturn(Some(ValidationMessage("description.language", "Error")))
+    when(titleValidator.validate(ValidLearningPath.title, false)).thenReturn(List())
+    when(languageValidator.validate("tags.language", "nb", false)).thenReturn(None)
 
-    val validationErrors = validator.validateLearningPath(ValidLearningPath.copy(description = List(Description("Gyldig beskrivelse", "bergensk"))))
+    val validationErrors = validator.validateLearningPath(ValidLearningPath.copy(description = List(Description("Gyldig beskrivelse", "bergensk"))), false)
     validationErrors.size should be (1)
     validationErrors.head.field should equal("description.language")
   }
 
   test("That validate returns error message when description contains html even if description is not required") {
     validMock()
-    val validationErrors = new LearningPathValidator(descriptionRequired = false).validateLearningPath(ValidLearningPath.copy(description = List(Description("<h1>Ugyldig</h1>", "nb"))))
+    val validationErrors = new LearningPathValidator(descriptionRequired = false).validateLearningPath(ValidLearningPath.copy(description = List(Description("<h1>Ugyldig</h1>", "nb"))), false)
     validationErrors.size should be (1)
     validationErrors.head.field should equal("description.description")
   }
 
   test("That validate returns error when description has an illegal language even if description is not required") {
-    when(languageValidator.validate("description.language", "bergensk")).thenReturn(Some(ValidationMessage("description.language", "Error")))
-    when(titleValidator.validate(ValidLearningPath.title)).thenReturn(List())
-    when(languageValidator.validate("tags.language", "nb")).thenReturn(None)
+    when(languageValidator.validate("description.language", "bergensk", false)).thenReturn(Some(ValidationMessage("description.language", "Error")))
+    when(titleValidator.validate(ValidLearningPath.title, false)).thenReturn(List())
+    when(languageValidator.validate("tags.language", "nb", false)).thenReturn(None)
 
-    val validationErrors = new LearningPathValidator(descriptionRequired = false).validateLearningPath(ValidLearningPath.copy(description = List(Description("Gyldig beskrivelse", "bergensk"))))
+    val validationErrors = new LearningPathValidator(descriptionRequired = false).validateLearningPath(ValidLearningPath.copy(description = List(Description("Gyldig beskrivelse", "bergensk"))), false)
     validationErrors.size should be (1)
     validationErrors.head.field should equal("description.language")
   }
 
   test("That DescriptionValidator validates both description text and language") {
-    when(languageValidator.validate("description.language", "bergensk")).thenReturn(Some(ValidationMessage("description.language", "Error")))
-    when(titleValidator.validate(ValidLearningPath.title)).thenReturn(List())
-    when(languageValidator.validate("tags.language", "nb")).thenReturn(None)
+    when(languageValidator.validate("description.language", "bergensk", false)).thenReturn(Some(ValidationMessage("description.language", "Error")))
+    when(titleValidator.validate(ValidLearningPath.title, false)).thenReturn(List())
+    when(languageValidator.validate("tags.language", "nb", false)).thenReturn(None)
 
-    val validationErrors = validator.validateLearningPath(ValidLearningPath.copy(description = List(Description("<h1>Ugyldig</h1>", "bergensk"))))
+    val validationErrors = validator.validateLearningPath(ValidLearningPath.copy(description = List(Description("<h1>Ugyldig</h1>", "bergensk"))), false)
     validationErrors.size should be (2)
     validationErrors.head.field should equal("description.description")
     validationErrors.last.field should equal("description.language")
@@ -151,7 +150,7 @@ class LearningPathValidatorTest extends UnitSuite with Clock with TestEnvironmen
       Description("Gyldig", "nb"),
       Description("<h1>Ugyldig</h1>", "nb"),
       Description("<h2>Også ugyldig</h2>", "nb")
-    )))
+    )), false)
 
     validationErrors.size should be (2)
     validationErrors.head.field should equal("description.description")
@@ -160,39 +159,39 @@ class LearningPathValidatorTest extends UnitSuite with Clock with TestEnvironmen
 
   test("That validate returns error when duration less than 1") {
     validMock()
-    val validationError = validator.validateLearningPath(ValidLearningPath.copy(duration = Some(0)))
+    val validationError = validator.validateLearningPath(ValidLearningPath.copy(duration = Some(0)), false)
     validationError.size should be (1)
     validationError.head.field should equal("duration")
   }
 
   test("That validate accepts a learningpath without duration") {
     validMock()
-    validator.validateLearningPath(ValidLearningPath.copy(duration = None)) should equal (List())
+    validator.validateLearningPath(ValidLearningPath.copy(duration = None), false) should equal (List())
   }
 
   test("That validate returns error when tag contains html") {
     validMock()
-    val validationErrors = validator.validateLearningPath(ValidLearningPath.copy(tags = List(LearningPathTags(Seq("<strong>ugyldig</strong>"), "nb"))))
+    val validationErrors = validator.validateLearningPath(ValidLearningPath.copy(tags = List(LearningPathTags(Seq("<strong>ugyldig</strong>"), "nb"))), false)
     validationErrors.size should be (1)
     validationErrors.head.field should equal("tags.tags")
   }
 
   test("That validate returns error when tag language is invalid") {
-    when(languageValidator.validate("description.language", "nb")).thenReturn(None)
-    when(titleValidator.validate(ValidLearningPath.title)).thenReturn(List())
-    when(languageValidator.validate("tags.language", "bergensk")).thenReturn(Some(ValidationMessage("tags.language", "Error")))
+    when(languageValidator.validate("description.language", "nb", false)).thenReturn(None)
+    when(titleValidator.validate(ValidLearningPath.title, false)).thenReturn(List())
+    when(languageValidator.validate("tags.language", "bergensk", false)).thenReturn(Some(ValidationMessage("tags.language", "Error")))
 
-    val validationErrors = validator.validateLearningPath(ValidLearningPath.copy(tags = List(LearningPathTags(Seq("Gyldig"), "bergensk"))))
+    val validationErrors = validator.validateLearningPath(ValidLearningPath.copy(tags = List(LearningPathTags(Seq("Gyldig"), "bergensk"))), false)
     validationErrors.size should be (1)
     validationErrors.head.field should equal("tags.language")
   }
 
   test("That returns error for both tag text and tag language") {
-    when(languageValidator.validate("description.language", "nb")).thenReturn(None)
-    when(titleValidator.validate(ValidLearningPath.title)).thenReturn(List())
-    when(languageValidator.validate("tags.language", "bergensk")).thenReturn(Some(ValidationMessage("tags.language", "Error")))
+    when(languageValidator.validate("description.language", "nb", false)).thenReturn(None)
+    when(titleValidator.validate(ValidLearningPath.title, false)).thenReturn(List())
+    when(languageValidator.validate("tags.language", "bergensk", false)).thenReturn(Some(ValidationMessage("tags.language", "Error")))
 
-    val validationErrors = validator.validateLearningPath(ValidLearningPath.copy(tags = List(LearningPathTags(Seq("<strong>ugyldig</strong>"), "bergensk"))))
+    val validationErrors = validator.validateLearningPath(ValidLearningPath.copy(tags = List(LearningPathTags(Seq("<strong>ugyldig</strong>"), "bergensk"))), false)
     validationErrors.size should be (2)
     validationErrors.head.field should equal("tags.tags")
     validationErrors.last.field should equal("tags.language")
@@ -202,7 +201,7 @@ class LearningPathValidatorTest extends UnitSuite with Clock with TestEnvironmen
     validMock()
     val validationErrors = validator.validateLearningPath(ValidLearningPath.copy(tags = List(
       LearningPathTags(Seq("<strong>ugyldig</strong>", "<li>også ugyldig</li>"), "nb")
-    )))
+    )), false)
     validationErrors.size should be (2)
     validationErrors.head.field should equal("tags.tags")
     validationErrors.last.field should equal("tags.tags")
@@ -212,26 +211,26 @@ class LearningPathValidatorTest extends UnitSuite with Clock with TestEnvironmen
     validMock()
     val invalidLicense = "dummy license"
     val invalidCopyright = ValidLearningPath.copyright.copy(license = invalidLicense)
-    val validationErrors = validator.validateLearningPath(ValidLearningPath.copy(copyright = invalidCopyright))
+    val validationErrors = validator.validateLearningPath(ValidLearningPath.copy(copyright = invalidCopyright), false)
 
     validationErrors.size should be (1)
   }
 
   test("That validate returns no errors when license is valid") {
     validMock()
-    validator.validateLearningPath(ValidLearningPath).isEmpty should be (true)
+    validator.validateLearningPath(ValidLearningPath, false).isEmpty should be (true)
   }
 
   test("That validate returns error when copyright.contributors contains html") {
     validMock()
     val invalidCopyright = ValidLearningPath.copyright.copy(contributors = List(Author("<h1>wizardry</h1>", "<h1>Gandalf</h1>")))
-    val validationErrors = validator.validateLearningPath(ValidLearningPath.copy(copyright = invalidCopyright))
+    val validationErrors = validator.validateLearningPath(ValidLearningPath.copy(copyright = invalidCopyright), false)
     validationErrors.size should be (2)
   }
 
   test("That validate returns no errors when copyright.contributors contains no html") {
     validMock()
-    validator.validateLearningPath(ValidLearningPath).isEmpty should be (true)
+    validator.validateLearningPath(ValidLearningPath, false).isEmpty should be (true)
   }
 }
 

--- a/src/test/scala/no/ndla/learningpathapi/validation/LearningStepValidatorTest.scala
+++ b/src/test/scala/no/ndla/learningpathapi/validation/LearningStepValidatorTest.scala
@@ -33,37 +33,37 @@ class LearningStepValidatorTest extends UnitSuite with TestEnvironment {
     resetMocks()
   }
   private def validMock() = {
-    when(languageValidator.validate("description.language", "nb")).thenReturn(None)
-    when(titleValidator.validate(ValidLearningStep.title)).thenReturn(List())
-    when(languageValidator.validate("embedUrl.language", "nb")).thenReturn(None)
+    when(languageValidator.validate("description.language", "nb", false)).thenReturn(None)
+    when(titleValidator.validate(ValidLearningStep.title, false)).thenReturn(List())
+    when(languageValidator.validate("embedUrl.language", "nb", false)).thenReturn(None)
   }
 
   test("That a valid learningstep does not give an error") {
     validMock()
-    validator.validateLearningStep(ValidLearningStep) should equal(List())
+    validator.validateLearningStep(ValidLearningStep, false) should equal(List())
   }
 
   test("That validate returns error message when description contains illegal html") {
     validMock()
-    val validationErrors = validator.validateLearningStep(ValidLearningStep.copy(description = List(Description("<h1>Ugyldig</h1>", "nb"))))
+    val validationErrors = validator.validateLearningStep(ValidLearningStep.copy(description = List(Description("<h1>Ugyldig</h1>", "nb"))), false)
     validationErrors.size should be(1)
     validationErrors.head.field should equal("description.description")
   }
 
   test("That validate returns error when description has an illegal language") {
-    when(languageValidator.validate("description.language", "bergensk")).thenReturn(Some(ValidationMessage("description.language", "Error")))
-    when(titleValidator.validate(ValidLearningStep.title)).thenReturn(List())
-    when(languageValidator.validate("embedUrl.language", "nb")).thenReturn(None)
-    val validationErrors = validator.validateLearningStep(ValidLearningStep.copy(description = List(Description("<strong>Gyldig beskrivelse</strong>", "bergensk"))))
+    when(languageValidator.validate("description.language", "bergensk", false)).thenReturn(Some(ValidationMessage("description.language", "Error")))
+    when(titleValidator.validate(ValidLearningStep.title, false)).thenReturn(List())
+    when(languageValidator.validate("embedUrl.language", "nb", false)).thenReturn(None)
+    val validationErrors = validator.validateLearningStep(ValidLearningStep.copy(description = List(Description("<strong>Gyldig beskrivelse</strong>", "bergensk"))), false)
     validationErrors.size should be(1)
     validationErrors.head.field should equal("description.language")
   }
 
   test("That DescriptionValidator validates both description text and language") {
-    when(languageValidator.validate("description.language", "bergensk")).thenReturn(Some(ValidationMessage("description.language", "Error")))
-    when(titleValidator.validate(ValidLearningStep.title)).thenReturn(List())
-    when(languageValidator.validate("embedUrl.language", "nb")).thenReturn(None)
-    val validationErrors = validator.validateLearningStep(ValidLearningStep.copy(description = List(Description("<h1>Ugyldig</h1>", "bergensk"))))
+    when(languageValidator.validate("description.language", "bergensk", false)).thenReturn(Some(ValidationMessage("description.language", "Error")))
+    when(titleValidator.validate(ValidLearningStep.title, false)).thenReturn(List())
+    when(languageValidator.validate("embedUrl.language", "nb", false)).thenReturn(None)
+    val validationErrors = validator.validateLearningStep(ValidLearningStep.copy(description = List(Description("<h1>Ugyldig</h1>", "bergensk"))), false)
     validationErrors.size should be(2)
     validationErrors.head.field should equal("description.description")
     validationErrors.last.field should equal("description.language")
@@ -75,7 +75,7 @@ class LearningStepValidatorTest extends UnitSuite with TestEnvironment {
       Description("<strong>Gyldig</strong>", "nb"),
       Description("<h1>Ugyldig</h1>", "nb"),
       Description("<h2>Også ugyldig</h2>", "nb")
-    )))
+    )), false)
 
     validationErrors.size should be(2)
     validationErrors.head.field should equal("description.description")
@@ -84,42 +84,42 @@ class LearningStepValidatorTest extends UnitSuite with TestEnvironment {
 
   test("That validate returns error when embedUrl contains html") {
     validMock()
-    val validationMessages = validator.validateLearningStep(ValidLearningStep.copy(embedUrl = List(EmbedUrl("<strong>ikke gyldig</strong>", "nb", EmbedType.OEmbed))))
+    val validationMessages = validator.validateLearningStep(ValidLearningStep.copy(embedUrl = List(EmbedUrl("<strong>ikke gyldig</strong>", "nb", EmbedType.OEmbed))), false)
     validationMessages.size should be(2)
     validationMessages.head.field should equal("embedUrl.url")
   }
 
   test("That validate returns error when embedUrl.language is invalid") {
-    when(languageValidator.validate("description.language", "nb")).thenReturn(None)
-    when(titleValidator.validate(ValidLearningStep.title)).thenReturn(List())
-    when(languageValidator.validate("embedUrl.language", "bergensk")).thenReturn(Some(ValidationMessage("embedUrl.language", "Error")))
-    val validationMessages = validator.validateLearningStep(ValidLearningStep.copy(embedUrl = List(EmbedUrl("https://www.ndla.no/123", "bergensk", EmbedType.OEmbed))))
+    when(languageValidator.validate("description.language", "nb", false)).thenReturn(None)
+    when(titleValidator.validate(ValidLearningStep.title, false)).thenReturn(List())
+    when(languageValidator.validate("embedUrl.language", "bergensk", false)).thenReturn(Some(ValidationMessage("embedUrl.language", "Error")))
+    val validationMessages = validator.validateLearningStep(ValidLearningStep.copy(embedUrl = List(EmbedUrl("https://www.ndla.no/123", "bergensk", EmbedType.OEmbed))), false)
     validationMessages.size should be(1)
     validationMessages.head.field should equal("embedUrl.language")
   }
 
   test("That validate returns error for both embedUrl.url and embedUrl.language") {
-    when(languageValidator.validate("description.language", "nb")).thenReturn(None)
-    when(titleValidator.validate(ValidLearningStep.title)).thenReturn(List())
-    when(languageValidator.validate("embedUrl.language", "bergensk")).thenReturn(Some(ValidationMessage("embedUrl.language", "Error")))
+    when(languageValidator.validate("description.language", "nb", false)).thenReturn(None)
+    when(titleValidator.validate(ValidLearningStep.title, false)).thenReturn(List())
+    when(languageValidator.validate("embedUrl.language", "bergensk", false)).thenReturn(Some(ValidationMessage("embedUrl.language", "Error")))
 
-    val validationMessages = validator.validateLearningStep(ValidLearningStep.copy(embedUrl = List(EmbedUrl("<h1>Ugyldig</h1>", "bergensk", EmbedType.OEmbed))))
+    val validationMessages = validator.validateLearningStep(ValidLearningStep.copy(embedUrl = List(EmbedUrl("<h1>Ugyldig</h1>", "bergensk", EmbedType.OEmbed))), false)
     validationMessages.size should be(3)
     validationMessages.head.field should equal("embedUrl.url")
     validationMessages.last.field should equal("embedUrl.language")
   }
 
   test("That all embedUrls are validated") {
-    when(languageValidator.validate("description.language", "nb")).thenReturn(None)
-    when(titleValidator.validate(ValidLearningStep.title)).thenReturn(List())
-    when(languageValidator.validate("embedUrl.language", "bergensk")).thenReturn(Some(ValidationMessage("embedUrl.language", "Error")))
-    when(languageValidator.validate("embedUrl.language", "nb")).thenReturn(None)
+    when(languageValidator.validate("description.language", "nb", false)).thenReturn(None)
+    when(titleValidator.validate(ValidLearningStep.title, false)).thenReturn(List())
+    when(languageValidator.validate("embedUrl.language", "bergensk", false)).thenReturn(Some(ValidationMessage("embedUrl.language", "Error")))
+    when(languageValidator.validate("embedUrl.language", "nb", false)).thenReturn(None)
 
     val validationMessages = validator.validateLearningStep(ValidLearningStep.copy(embedUrl =
       List(
         EmbedUrl("<h1>Ugyldig</h1>", "nb", EmbedType.OEmbed),
         EmbedUrl("https://www.ndla.no/123", "bergensk", EmbedType.OEmbed)
-      )))
+      )), false)
     validationMessages.size should be(3)
     validationMessages.head.field should equal("embedUrl.url")
     validationMessages.last.field should equal("embedUrl.language")
@@ -128,19 +128,19 @@ class LearningStepValidatorTest extends UnitSuite with TestEnvironment {
   test("That html-code in license returns an error") {
     validMock()
     val license = "<strong>ugyldig</strong>"
-    val validationMessages = validator.validateLearningStep(ValidLearningStep.copy(license = Some(license)))
+    val validationMessages = validator.validateLearningStep(ValidLearningStep.copy(license = Some(license)), false)
     validationMessages.size should be(1)
     validationMessages.head.field should equal("license")
   }
 
   test("That None-license doesn't give an error") {
     validMock()
-    validator.validateLearningStep(ValidLearningStep.copy(license = None)) should equal(List())
+    validator.validateLearningStep(ValidLearningStep.copy(license = None), false) should equal(List())
   }
 
   test("That error is returned when no descriptions or embedUrls are defined") {
     validMock()
-    val validationErrors = validator.validateLearningStep(ValidLearningStep.copy(description = List(), embedUrl = Seq()))
+    val validationErrors = validator.validateLearningStep(ValidLearningStep.copy(description = List(), embedUrl = Seq()), false)
     validationErrors.size should be(1)
     validationErrors.head.field should equal("description|embedUrl")
     validationErrors.head.message should equal("A learningstep is required to have either a description, embedUrl or both.")
@@ -148,12 +148,12 @@ class LearningStepValidatorTest extends UnitSuite with TestEnvironment {
 
   test("That no error is returned when a description is present, but no embedUrls") {
     validMock()
-    validator.validateLearningStep(ValidLearningStep.copy(embedUrl = Seq())) should equal(Seq())
+    validator.validateLearningStep(ValidLearningStep.copy(embedUrl = Seq()), false) should equal(Seq())
   }
 
   test("That no error is returned when an embedUrl is present, but no descriptions") {
     validMock()
-    validator.validateLearningStep(ValidLearningStep.copy(description = List())) should equal(List())
+    validator.validateLearningStep(ValidLearningStep.copy(description = List()), false) should equal(List())
   }
 }
 

--- a/src/test/scala/no/ndla/learningpathapi/validation/TitleValidatorTest.scala
+++ b/src/test/scala/no/ndla/learningpathapi/validation/TitleValidatorTest.scala
@@ -25,29 +25,29 @@ class TitleValidatorTest extends UnitSuite with TestEnvironment{
   val DefaultTitle = Title("Some title", "nb")
 
   test("That TitleValidator.validate returns error message when no titles are defined") {
-    val errorMessages = validator.validate(List())
+    val errorMessages = validator.validate(List(), false)
     errorMessages.size should be (1)
     errorMessages.head.field should equal("title")
     errorMessages.head.message should equal("At least one title is required.")
   }
 
   test("That TitleValidator validates title text") {
-    when(languageValidator.validate("title.language", "nb")).thenReturn(None)
-    val validationErrors = validator.validate(List(DefaultTitle.copy(title = "<h1>Illegal text</h1>")))
+    when(languageValidator.validate("title.language", "nb", false)).thenReturn(None)
+    val validationErrors = validator.validate(List(DefaultTitle.copy(title = "<h1>Illegal text</h1>")), false)
     validationErrors.size should be (1)
     validationErrors.head.field should equal("title.title")
   }
 
   test("That TitleValidator validates language") {
-    when(languageValidator.validate("title.language", "bergensk")).thenReturn(Some(ValidationMessage("title.language", "Error")))
-    val validationErrors = validator.validate(List(DefaultTitle.copy(language = "bergensk")))
+    when(languageValidator.validate("title.language", "bergensk", false)).thenReturn(Some(ValidationMessage("title.language", "Error")))
+    val validationErrors = validator.validate(List(DefaultTitle.copy(language = "bergensk")), false)
     validationErrors.size should be (1)
     validationErrors.head.field should equal("title.language")
   }
 
   test("That TitleValidator validates both title text and language") {
-    when(languageValidator.validate("title.language", "bergensk")).thenReturn(Some(ValidationMessage("title.language", "Error")))
-    val validationErrors = validator.validate(List(DefaultTitle.copy(title = "<h1>Illegal text</h1>", language = "bergensk")))
+    when(languageValidator.validate("title.language", "bergensk", false)).thenReturn(Some(ValidationMessage("title.language", "Error")))
+    val validationErrors = validator.validate(List(DefaultTitle.copy(title = "<h1>Illegal text</h1>", language = "bergensk")), false)
     validationErrors.size should be (2)
     validationErrors.head.field should equal("title.title")
     validationErrors.last.field should equal("title.language")
@@ -55,29 +55,29 @@ class TitleValidatorTest extends UnitSuite with TestEnvironment{
   }
 
   test("That TitleValidator returns no errors for a valid title") {
-    when(languageValidator.validate("title.language", "nb")).thenReturn(None)
-    validator.validate(List(DefaultTitle)) should equal(List())
+    when(languageValidator.validate("title.language", "nb", false)).thenReturn(None)
+    validator.validate(List(DefaultTitle), false) should equal(List())
   }
 
   test("That TitleValidator validates all titles") {
-    when(languageValidator.validate("title.language", "nb")).thenReturn(None)
+    when(languageValidator.validate("title.language", "nb", false)).thenReturn(None)
     val validationErrors = validator.validate(List(
       DefaultTitle.copy(title = "<h1>Invalid text</h1>"),
       DefaultTitle.copy(title = "<h1>Invalid text</h1>")
-    ))
+    ), false)
     validationErrors.size should be (2)
     validationErrors.head.field should equal("title.title")
     validationErrors.last.field should equal("title.title")
   }
 
   test("That TitleValidator does not return error message when no titles are defined and no titles are required") {
-    when(languageValidator.validate("title.language", "nb")).thenReturn(None)
-    new TitleValidator(titleRequired = false).validate(List()) should equal(List())
+    when(languageValidator.validate("title.language", "nb", false)).thenReturn(None)
+    new TitleValidator(titleRequired = false).validate(List(), false) should equal(List())
   }
 
   test("That TitleValidator returns error message for an invalid title even if no titles are required") {
-    when(languageValidator.validate("title.language", "nb")).thenReturn(None)
-    val validationErrors = new TitleValidator(titleRequired = false).validate(List(DefaultTitle.copy(title = "<h1>Invalid text</h1>")))
+    when(languageValidator.validate("title.language", "nb", false)).thenReturn(None)
+    val validationErrors = new TitleValidator(titleRequired = false).validate(List(DefaultTitle.copy(title = "<h1>Invalid text</h1>")), false)
     validationErrors.size should be (1)
     validationErrors.head.field should equal("title.title")
   }


### PR DESCRIPTION
Veldig mange linjer som måtte endres for ganske lite (i all hovedsak tester).
La til et nyt parameter til `LanguageValidator` som styrer om "unknown" skal være gyldig som språk. For kopier-læringssti-funksjonaliteten kom vi frem til at det var rikitg, mtp. at noen importerte læringsstier har "unknown" språkfelter