### PR TITLE
NDLANO/Issues#580 pagination over 10000 results

### DIFF
--- a/src/main/scala/no/ndla/learningpathapi/LearningpathApiProperties.scala
+++ b/src/main/scala/no/ndla/learningpathapi/LearningpathApiProperties.scala
@@ -45,6 +45,7 @@ object LearningpathApiProperties extends LazyLogging {
 
   val IsoMappingCacheAgeInMs = 1000 * 60 * 60 // 1 hour caching
   val LicenseMappingCacheAgeInMs = 1000 * 60 * 60 // 1 hour caching
+  val ElasticSearchIndexMaxResultWindow = 10000
 
   val BasicHtmlTags = List("b", "blockquote", "br", "cite", "code", "dd", "dl", "dt", "em",
     "i", "li", "ol", "p", "pre", "q", "small", "strike", "strong",

--- a/src/main/scala/no/ndla/learningpathapi/controller/NdlaController.scala
+++ b/src/main/scala/no/ndla/learningpathapi/controller/NdlaController.scala
@@ -13,7 +13,7 @@ import javax.servlet.http.HttpServletRequest
 
 import com.typesafe.scalalogging.LazyLogging
 import no.ndla.learningpathapi.model.api.{Error, ValidationError, ValidationMessage}
-import no.ndla.learningpathapi.model.domain.{AccessDeniedException, OptimisticLockException, ValidationException}
+import no.ndla.learningpathapi.model.domain.{AccessDeniedException, OptimisticLockException, ResultWindowTooLargeException, ValidationException}
 import no.ndla.network.{ApplicationUrl, AuthUser}
 import no.ndla.network.model.HttpRequestException
 import org.json4s.native.Serialization.read
@@ -40,6 +40,7 @@ abstract class NdlaController extends ScalatraServlet with NativeJsonSupport wit
     case a: AccessDeniedException => halt(status = 403, body = Error(Error.ACCESS_DENIED, a.getMessage))
     case ole: OptimisticLockException => halt(status = 409, body = Error(Error.RESOURCE_OUTDATED, Error.RESOURCE_OUTDATED_DESCRIPTION))
     case hre: HttpRequestException => halt(status = 502, body = Error(Error.REMOTE_ERROR, hre.getMessage))
+    case rw: ResultWindowTooLargeException => UnprocessableEntity(body = Error(Error.WINDOW_TOO_LARGE, rw.getMessage))
     case t: Throwable => {
       t.printStackTrace()
       logger.error(t.getMessage)

--- a/src/main/scala/no/ndla/learningpathapi/model/api/Error.scala
+++ b/src/main/scala/no/ndla/learningpathapi/model/api/Error.scala
@@ -30,8 +30,10 @@ object Error {
   val ACCESS_DENIED = "ACCESS_DENIED"
   val REMOTE_ERROR = "REMOTE_ERROR"
   val RESOURCE_OUTDATED = "RESOURCE_OUTDATED"
+  val WINDOW_TOO_LARGE = "RESULT WINDOW TOO LARGE"
 
   val GENERIC_DESCRIPTION = s"Ooops. Something we didn't anticipate occured. We have logged the error, and will look into it. But feel free to contact ${LearningpathApiProperties.ContactEmail} if the error persists."
   val VALIDATION_DESCRIPTION = "Validation Error"
   val RESOURCE_OUTDATED_DESCRIPTION = "The resource is outdated. Please try fetching before submitting again."
+  val WindowTooLargeError = Error(WINDOW_TOO_LARGE, s"The result window is too large. Fetching pages above ${LearningpathApiProperties.ElasticSearchIndexMaxResultWindow} results are unsupported.")
 }

--- a/src/main/scala/no/ndla/learningpathapi/model/domain/NDLAErrors.scala
+++ b/src/main/scala/no/ndla/learningpathapi/model/domain/NDLAErrors.scala
@@ -17,3 +17,4 @@ class OptimisticLockException(message: String) extends RuntimeException(message)
 class NdlaSearchException(jestResponse: JestResult) extends RuntimeException(jestResponse.getErrorMessage) {
   def getResponse: JestResult = jestResponse
 }
+class ResultWindowTooLargeException(message: String) extends RuntimeException(message)

--- a/src/main/scala/no/ndla/learningpathapi/service/search/SearchIndexServiceComponent.scala
+++ b/src/main/scala/no/ndla/learningpathapi/service/search/SearchIndexServiceComponent.scala
@@ -112,7 +112,9 @@ trait SearchIndexServiceComponent {
       if (indexExists(indexName).getOrElse(false)) {
         Success(indexName)
       } else {
-        val createIndexResponse = jestClient.execute(new CreateIndex.Builder(indexName).build())
+        val createIndexResponse = jestClient.execute(new CreateIndex.Builder(indexName)
+          .settings(s"""{"index":{"max_result_window":${LearningpathApiProperties.ElasticSearchIndexMaxResultWindow}}}""")
+          .build())
         createIndexResponse.map(_ => createMapping(indexName)).map(_ => indexName)
       }
     }


### PR DESCRIPTION
- Setter `index.max_result_window` verdien i elasticsearch når index'er lages
- Error handling når det requestes pages etter `index.max_result_window` results