### PR TITLE
#1221: Message is updated in body instead of query-parameter.

### DIFF
--- a/src/main/scala/no/ndla/learningpathapi/model/api/LearningPathSummary.scala
+++ b/src/main/scala/no/ndla/learningpathapi/model/api/LearningPathSummary.scala
@@ -32,4 +32,8 @@ case class LearningPathSummaryV2(
     @(ApiModelProperty @field)(description = "The contributors of this learningpath") copyright: Copyright,
     @(ApiModelProperty @field)(description = "A list of available languages for this audio") supportedLanguages: Seq[
       String],
-    @(ApiModelProperty @field)(description = "The id this learningpath is based on, if any") isBasedOn: Option[Long])
+    @(ApiModelProperty @field)(description = "The id this learningpath is based on, if any") isBasedOn: Option[Long],
+    @(ApiModelProperty @field)(description =
+      "Message that admins can place on a LearningPath for notifying a owner of issues with the LearningPath") message: Option[
+      String]
+)

--- a/src/main/scala/no/ndla/learningpathapi/model/api/LearningPathSummary.scala
+++ b/src/main/scala/no/ndla/learningpathapi/model/api/LearningPathSummary.scala
@@ -18,6 +18,7 @@ import scala.annotation.meta.field
 @ApiModel(description = "Summary of meta information for a learningpath")
 case class LearningPathSummaryV2(
     @(ApiModelProperty @field)(description = "The unique id of the learningpath") id: Long,
+    @(ApiModelProperty @field)(description = "The revision number for this learningpath") revision: Option[Int],
     @(ApiModelProperty @field)(description = "The titles of the learningpath") title: Title,
     @(ApiModelProperty @field)(description = "The descriptions of the learningpath") description: Description,
     @(ApiModelProperty @field)(description = "The introductions of the learningpath") introduction: Introduction,
@@ -35,5 +36,4 @@ case class LearningPathSummaryV2(
     @(ApiModelProperty @field)(description = "The id this learningpath is based on, if any") isBasedOn: Option[Long],
     @(ApiModelProperty @field)(description =
       "Message that admins can place on a LearningPath for notifying a owner of issues with the LearningPath") message: Option[
-      String]
-)
+      String])

--- a/src/main/scala/no/ndla/learningpathapi/model/api/Message.scala
+++ b/src/main/scala/no/ndla/learningpathapi/model/api/Message.scala
@@ -6,7 +6,7 @@
  */
 
 package no.ndla.learningpathapi.model.api
-import org.joda.time.DateTime
+import java.util.Date
 import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
 
 import scala.annotation.meta.field
@@ -14,4 +14,4 @@ import scala.annotation.meta.field
 @ApiModel(description = "Administrator message left on learningpaths")
 case class Message(
     @(ApiModelProperty @field)(description = "Message left on a learningpath by administrator") message: String,
-    @(ApiModelProperty @field)(description = "When the message was left") date: DateTime)
+    @(ApiModelProperty @field)(description = "When the message was left") date: Date)

--- a/src/main/scala/no/ndla/learningpathapi/model/api/UpdateLearningPathStatus.scala
+++ b/src/main/scala/no/ndla/learningpathapi/model/api/UpdateLearningPathStatus.scala
@@ -1,0 +1,19 @@
+/*
+ * Part of NDLA learningpath-api.
+ * Copyright (C) 2018 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.learningpathapi.model.api
+import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
+
+import scala.annotation.meta.field
+
+@ApiModel(description = "Status information about a learningpath")
+case class UpdateLearningPathStatus(
+    @(ApiModelProperty @field)(description = "The publishing status of the learningpath",
+                               allowableValues = "PUBLISHED,PRIVATE,DELETED,UNLISTED,SUBMITTED") status: String,
+    @(ApiModelProperty @field)(description =
+      "Message that admins can place on a LearningPath for notifying a owner of issues with the LearningPath") message: Option[
+      String])

--- a/src/main/scala/no/ndla/learningpathapi/model/domain/LearningPath.scala
+++ b/src/main/scala/no/ndla/learningpathapi/model/domain/LearningPath.scala
@@ -14,7 +14,7 @@ import java.util.Date
 import no.ndla.learningpathapi.LearningpathApiProperties
 import no.ndla.learningpathapi.model.api.ValidationMessage
 import no.ndla.learningpathapi.validation.{DurationValidator, LearningPathValidator, LearningStepValidator}
-import org.json4s.FieldSerializer
+import org.json4s.{DefaultFormats, FieldSerializer, Formats}
 import org.json4s.FieldSerializer._
 import org.json4s.ext.EnumNameSerializer
 import org.json4s.native.Serialization._
@@ -135,8 +135,9 @@ object LearningPathVerificationStatus extends Enumeration {
 }
 
 object LearningPath extends SQLSyntaxSupport[LearningPath] {
-  implicit val formats = org.json4s.DefaultFormats + new EnumNameSerializer(LearningPathStatus) + new EnumNameSerializer(
-    LearningPathVerificationStatus)
+  implicit val formats = org.json4s.DefaultFormats +
+    new EnumNameSerializer(LearningPathStatus) +
+    new EnumNameSerializer(LearningPathVerificationStatus)
   override val tableName = "learningpaths"
   override val schemaName = Some(LearningpathApiProperties.MetaSchema)
 
@@ -144,21 +145,10 @@ object LearningPath extends SQLSyntaxSupport[LearningPath] {
 
   def apply(lp: ResultName[LearningPath])(rs: WrappedResultSet): LearningPath = {
     val meta = read[LearningPath](rs.string(lp.c("document")))
-    LearningPath(
-      Some(rs.long(lp.c("id"))),
-      Some(rs.int(lp.c("revision"))),
-      rs.stringOpt(lp.c("external_id")),
-      meta.isBasedOn,
-      meta.title,
-      meta.description,
-      meta.coverPhotoId,
-      meta.duration,
-      meta.status,
-      meta.verificationStatus,
-      meta.lastUpdated,
-      meta.tags,
-      meta.owner,
-      meta.copyright
+    meta.copy(
+      id = Some(rs.long(lp.c("id"))),
+      revision = Some(rs.int(lp.c("revision"))),
+      externalId = rs.stringOpt(lp.c("external_id"))
     )
   }
 

--- a/src/main/scala/no/ndla/learningpathapi/model/domain/Message.scala
+++ b/src/main/scala/no/ndla/learningpathapi/model/domain/Message.scala
@@ -7,6 +7,6 @@
 
 package no.ndla.learningpathapi.model.domain
 
-import org.joda.time.DateTime
+import java.util.Date
 
-case class Message(message: String, adminName: String, date: DateTime)
+case class Message(message: String, adminName: String, date: Date)

--- a/src/main/scala/no/ndla/learningpathapi/repository/LearningPathRepositoryComponent.scala
+++ b/src/main/scala/no/ndla/learningpathapi/repository/LearningPathRepositoryComponent.scala
@@ -38,7 +38,8 @@ trait LearningPathRepositoryComponent extends LazyLogging {
       LearningStep.JSonSerializer +
       new EnumNameSerializer(LearningPathStatus) +
       new EnumNameSerializer(LearningPathVerificationStatus) +
-      new EnumNameSerializer(StepType)
+      new EnumNameSerializer(StepType) ++
+      org.json4s.ext.JodaTimeSerializers.all
 
     def withId(id: Long)(implicit session: DBSession = AutoSession): Option[LearningPath] = {
       learningPathWhere(sqls"lp.id = $id AND lp.document->>'status' <> ${LearningPathStatus.DELETED.toString}")

--- a/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
+++ b/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
@@ -386,7 +386,8 @@ trait ConverterService {
       supportedLanguages.isEmpty || (!supportedLanguages.contains(language) && language != AllLanguages)
     }
 
-    def asApiLearningpathSummaryV2(learningpath: domain.LearningPath): Try[api.LearningPathSummaryV2] = {
+    def asApiLearningpathSummaryV2(learningpath: domain.LearningPath,
+                                   user: UserInfo = UserInfo.get): Try[api.LearningPathSummaryV2] = {
       val supportedLanguages = findSupportedLanguages(learningpath)
 
       val title = findByLanguageOrBestEffort(learningpath.title, Some(Language.AllLanguages))
@@ -402,6 +403,8 @@ trait ConverterService {
         findByLanguageOrBestEffort(getApiIntroduction(learningpath.learningsteps), Some(Language.AllLanguages))
           .getOrElse(api.Introduction("", DefaultLanguage))
 
+      val message = learningpath.message.filter(_ => learningpath.canEdit(user)).map(_.message)
+
       Success(
         api.LearningPathSummaryV2(
           learningpath.id.get,
@@ -416,7 +419,8 @@ trait ConverterService {
           tags,
           asApiCopyright(learningpath.copyright),
           supportedLanguages,
-          learningpath.isBasedOn
+          learningpath.isBasedOn,
+          message
         )
       )
     }

--- a/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
+++ b/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
@@ -408,6 +408,7 @@ trait ConverterService {
       Success(
         api.LearningPathSummaryV2(
           learningpath.id.get,
+          revision = learningpath.revision,
           title,
           description,
           introduction,

--- a/src/main/scala/no/ndla/learningpathapi/service/ReadServiceComponent.scala
+++ b/src/main/scala/no/ndla/learningpathapi/service/ReadServiceComponent.scala
@@ -32,10 +32,10 @@ trait ReadServiceComponent {
       learningPathRepository.allPublishedContributors.map(author => Author(author.`type`, author.name))
     }
 
-    def withOwnerV2(owner: String): List[LearningPathSummaryV2] = {
+    def withOwnerV2(user: UserInfo = UserInfo.get): List[LearningPathSummaryV2] = {
       learningPathRepository
-        .withOwner(owner)
-        .flatMap(value => converterService.asApiLearningpathSummaryV2(value).toOption)
+        .withOwner(user.userId)
+        .flatMap(value => converterService.asApiLearningpathSummaryV2(value, user).toOption)
     }
 
     def withIdV2(learningPathId: Long, language: String, user: UserInfo = UserInfo.get): Option[LearningPathV2] = {

--- a/src/main/scala/no/ndla/learningpathapi/service/UpdateService.scala
+++ b/src/main/scala/no/ndla/learningpathapi/service/UpdateService.scala
@@ -92,7 +92,7 @@ trait UpdateService {
 
           val newMessage = message match {
             case Some(msg) if owner.isAdmin =>
-              Some(domain.Message(msg, owner.userId, new DateTime(clock.now())))
+              Some(domain.Message(msg, owner.userId, clock.now()))
             case _ => existing.message
           }
 

--- a/src/main/scala/no/ndla/learningpathapi/service/search/SearchConverterServiceComponent.scala
+++ b/src/main/scala/no/ndla/learningpathapi/service/search/SearchConverterServiceComponent.scala
@@ -113,7 +113,8 @@ trait SearchConverterServiceComponent {
           .getOrElse(api.LearningPathTags(Seq(), DefaultLanguage)),
         searchableLearningPath.copyright,
         supportedLanguages,
-        searchableLearningPath.isBasedOn
+        searchableLearningPath.isBasedOn,
+        message = None
       )
     }
 

--- a/src/main/scala/no/ndla/learningpathapi/service/search/SearchConverterServiceComponent.scala
+++ b/src/main/scala/no/ndla/learningpathapi/service/search/SearchConverterServiceComponent.scala
@@ -98,6 +98,7 @@ trait SearchConverterServiceComponent {
 
       LearningPathSummaryV2(
         searchableLearningPath.id,
+        revision = None,
         findByLanguageOrBestEffort(titles, Some(language))
           .getOrElse(api.Title("", DefaultLanguage)),
         findByLanguageOrBestEffort(descriptions, Some(language))

--- a/src/test/scala/no/ndla/learningpathapi/controller/LearningpathControllerV2Test.scala
+++ b/src/test/scala/no/ndla/learningpathapi/controller/LearningpathControllerV2Test.scala
@@ -34,6 +34,7 @@ class LearningpathControllerV2Test extends UnitSuite with TestEnvironment with S
 
   val DefaultLearningPathSummary = api.LearningPathSummaryV2(
     1,
+    None,
     api.Title("Tittel", "nb"),
     api.Description("", "nb"),
     api.Introduction("", "nb"),

--- a/src/test/scala/no/ndla/learningpathapi/controller/LearningpathControllerV2Test.scala
+++ b/src/test/scala/no/ndla/learningpathapi/controller/LearningpathControllerV2Test.scala
@@ -45,6 +45,7 @@ class LearningpathControllerV2Test extends UnitSuite with TestEnvironment with S
     api.LearningPathTags(Seq(), "nb"),
     copyright,
     List("nb"),
+    None,
     None
   )
 

--- a/src/test/scala/no/ndla/learningpathapi/repository/LearningPathRepositoryComponentIntegrationTest.scala
+++ b/src/test/scala/no/ndla/learningpathapi/repository/LearningPathRepositoryComponentIntegrationTest.scala
@@ -354,6 +354,28 @@ class LearningPathRepositoryComponentIntegrationTest extends IntegrationSuite wi
     repository.deletePath(learningPath3.id.get)
   }
 
+  test("That inserted and fetched entry stays the same") {
+    assume(databaseIsAvailable, "Database is unavailable")
+    val steps = Vector(
+      DefaultLearningStep,
+      DefaultLearningStep,
+      DefaultLearningStep
+    )
+
+    val path = DefaultLearningPath.copy(
+      learningsteps = steps,
+      status = LearningPathStatus.PRIVATE,
+      owner = "123",
+      message = Some(Message("this is message", "kwawk", clock.now()))
+    )
+
+    val inserted = repository.insert(path)
+    val fetched = repository.withId(inserted.id.get)
+
+    inserted should be(fetched.get)
+    repository.deletePath(inserted.id.get)
+  }
+
   def emptyTestDatabase = {
     DB autoCommit (implicit session => {
       sql"delete from learningpathapi_test.learningpaths;".execute.apply()(session)

--- a/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
+++ b/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
@@ -138,6 +138,7 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
                                   Some("https://creativecommons.org/licenses/by/2.0/")),
                       List.empty),
         List("nb", "en"),
+        None,
         None
       ))
     service.asApiLearningpathSummaryV2(domainLearningPath.copy(title = domainLearningPath.title :+ Title("test", "en"))) should equal(

--- a/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
+++ b/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
@@ -124,6 +124,7 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
     val expected = Success(
       api.LearningPathSummaryV2(
         1,
+        Some(1),
         api.Title("tittel", Language.DefaultLanguage),
         api.Description("deskripsjon", Language.DefaultLanguage),
         api.Introduction("", Language.DefaultLanguage),

--- a/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
+++ b/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
@@ -533,8 +533,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
                                        "nb",
                                        Some("new message"))
     verify(learningPathRepository, times(1)).update(
-      PUBLISHED_LEARNINGPATH.copy(message =
-                                    Some(Message("new message", PRIVATE_OWNER.userId, new DateTime(clock.now()))),
+      PUBLISHED_LEARNINGPATH.copy(message = Some(Message("new message", PRIVATE_OWNER.userId, clock.now())),
                                   status = LearningPathStatus.PRIVATE,
                                   lastUpdated = clock.now())
     )
@@ -1332,7 +1331,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
   test("That delete message field deletes admin message") {
     val newDate = new Date()
     val originalLearningPath =
-      PUBLISHED_LEARNINGPATH.copy(message = Some(Message("You need to fix some stuffs", "kari", new DateTime())))
+      PUBLISHED_LEARNINGPATH.copy(message = Some(Message("You need to fix some stuffs", "kari", clock.now())))
     when(learningPathRepository.withId(PUBLISHED_ID)).thenReturn(Some(originalLearningPath))
     when(learningPathRepository.learningStepWithId(eqTo(PUBLISHED_ID), eqTo(STEP1.id.get))(any[DBSession]))
       .thenReturn(Some(STEP1))


### PR DESCRIPTION
connects to NDLANO/Issues#1221
- Makes message a part of update status body rather than query parameter
- Adds messages to /mine/ endpoint
- Adds revision to /mine/ endpoint
- Fixes bug with retrieving messages from stored LearningPaths

