### PR TITLE
#1732: Adds migration for migrating learningpaths with owners with roles to CREATED_BY_NDLA status

### DIFF
--- a/src/main/scala/db/migration/V11__CreatedByNdlaStatusForOwnersWithRoles.scala
+++ b/src/main/scala/db/migration/V11__CreatedByNdlaStatusForOwnersWithRoles.scala
@@ -106,7 +106,7 @@ class V11__CreatedByNdlaStatusForOwnersWithRoles extends BaseJavaMigration with 
   private def getOwnerIdsWithRolesOnPage(token: String,
                                          page: Int,
                                          results: List[String] = List.empty): Try[List[String]] = {
-    val pageSize = 3
+    val pageSize = 50
     getAuth0Response(token, page, pageSize) match {
       case Failure(ex) => Failure(ex)
       case Success(response) =>

--- a/src/main/scala/db/migration/V11__CreatedByNdlaStatusForOwnersWithRoles.scala
+++ b/src/main/scala/db/migration/V11__CreatedByNdlaStatusForOwnersWithRoles.scala
@@ -1,0 +1,130 @@
+/*
+ * Part of NDLA learningpath-api.
+ * Copyright (C) 2019 NDLA
+ *
+ * See LICENSE
+ */
+
+package db.migration
+
+import com.typesafe.scalalogging.LazyLogging
+import no.ndla.learningpathapi.LearningpathApiProperties
+import no.ndla.learningpathapi.model.domain.LearningPathVerificationStatus
+import no.ndla.network.AuthUser
+import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
+import org.json4s.DefaultFormats
+import org.json4s.JsonAST.JString
+import org.json4s.native.JsonMethods.{compact, parse, render}
+import org.json4s.native.Serialization.{read, write}
+import org.postgresql.util.PGobject
+import scalaj.http.Http
+import scalikejdbc.{DB, DBSession, _}
+
+import scala.util.{Failure, Success, Try}
+
+class V11__CreatedByNdlaStatusForOwnersWithRoles extends BaseJavaMigration with LazyLogging {
+  implicit val formats: DefaultFormats.type = org.json4s.DefaultFormats
+  private val auth0Host = AuthUser.getAuth0HostForEnv(LearningpathApiProperties.Environment)
+
+  case class UserMetaDataObject(ndla_id: String)
+  case class UserResponseObject(app_metadata: UserMetaDataObject)
+  case class Auth0TokenRequestBody(grant_type: String, client_id: String, client_secret: String, audience: String)
+  case class Auth0TokenResponseBody(access_token: String)
+
+  override def migrate(context: Context): Unit = {
+    val db = DB(context.getConnection)
+    db.autoClose(false)
+    getOwnerIdsWithRoles match {
+      case Failure(ex) =>
+        logger.error("Something went wrong during fetching users from auth0.")
+        throw ex
+      case Success(ownerIds) =>
+        db.withinTx { implicit session =>
+          allLearningPathsWithOwnerInList(ownerIds)
+            .map { case (id, document) => (id, convertLearningPathDocument(document)) }
+            .foreach {
+              case (id, convertedDocument) =>
+                println(s"Setting the verificationStatus of $id to '${LearningPathVerificationStatus.CREATED_BY_NDLA}'")
+                updateLearningPath(id, convertedDocument)
+            }
+        }
+    }
+  }
+
+  def getAuth0Token: Try[String] = {
+    val requestBody = for {
+      client_id <- Try(LearningpathApiProperties.prop("LEARNINGPATH_CLIENT_ID"))
+      client_secret <- Try(LearningpathApiProperties.prop("LEARNINGPATH_CLIENT_SECRET"))
+    } yield
+      Auth0TokenRequestBody(
+        "client_credentials",
+        client_id,
+        client_secret,
+        s"https://$auth0Host/api/v2/"
+      )
+
+    requestBody
+      .flatMap(body => {
+        Try(
+          Http(s"https://$auth0Host/oauth/token")
+            .header("Content-Type", "application/json")
+            .postData(write(body))
+            .asString
+        )
+      })
+      .map(res =>
+        if (res.code == 200) {
+          read[Auth0TokenResponseBody](res.body).access_token
+        } else {
+          throw new RuntimeException("Could not fetch auth0 token for listing users with roles.")
+      })
+  }
+
+  def getOwnerIdsWithRoles: Try[List[String]] = {
+    val url = s"https://$auth0Host/api/v2/users"
+
+    getAuth0Token.flatMap(token => {
+      Try(
+        Http(url)
+          .params(
+            "search_engine" -> "v3",
+            "q" -> """app_metadata.roles:"learningpath:write" || app_metadata.roles:"learningpath:admin" || app_metadata.roles:"learningpath:publish""""
+          )
+          .header("Authorization", s"Bearer $token")
+          .method("GET")
+          .asString).map(res => read[List[UserResponseObject]](res.body).map(_.app_metadata.ndla_id))
+    })
+  }
+
+  def allLearningPathsWithOwnerInList(ownerList: List[String])(implicit session: DBSession): Seq[(Long, String)] = {
+    sql"select id, document from learningpaths where document->>'owner' in ($ownerList)"
+      .map(rs => {
+        (rs.long("id"), rs.string("document"))
+      })
+      .list()
+      .apply()
+  }
+
+  def convertLearningPathDocument(document: String): String = {
+    val oldArticle = parse(document)
+
+    val newPath = oldArticle.mapField {
+      case ("verificationStatus", _: JString) =>
+        "verificationStatus" -> JString(LearningPathVerificationStatus.CREATED_BY_NDLA.toString)
+      case x => x
+    }
+    compact(render(newPath))
+  }
+
+  def updateLearningPath(id: Long, document: String)(implicit session: DBSession): Int = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(document)
+
+    sql"update learningpaths set document = $dataObject where id = ${id}"
+      .update()
+      .apply
+  }
+
+  case class V9__LearningPath(owner: String)
+}

--- a/src/test/scala/db/migration/V11__CreatedByNdlaStatusForOwnersWithRolesTest.scala
+++ b/src/test/scala/db/migration/V11__CreatedByNdlaStatusForOwnersWithRolesTest.scala
@@ -1,0 +1,33 @@
+/*
+ * Part of NDLA learningpath-api.
+ * Copyright (C) 2019 NDLA
+ *
+ * See LICENSE
+ */
+
+package db.migration
+
+import no.ndla.learningpathapi.{TestEnvironment, UnitSuite}
+
+class V11__CreatedByNdlaStatusForOwnersWithRolesTest extends UnitSuite with TestEnvironment {
+  val migration = new V11__CreatedByNdlaStatusForOwnersWithRoles
+
+  test("That migration changes verificationStatus correctly") {
+    val old =
+      s"""{"verificationStatus":"EXTERNAL","copyright":{"license":"by","creators":[{"name":"henrik","type":"Writer"}],"processors":[],"rightsholders":[]},"title":[{"title":"tittel","language":"nb"}]}"""
+    val expected =
+      s"""{"verificationStatus":"CREATED_BY_NDLA","copyright":{"license":"by","creators":[{"name":"henrik","type":"Writer"}],"processors":[],"rightsholders":[]},"title":[{"title":"tittel","language":"nb"}]}"""
+
+    migration.convertLearningPathDocument(old) should be(expected)
+  }
+
+  test("That migration does not change anything if status is already CREATED_BY_NDLA") {
+    val old =
+      s"""{"verificationStatus":"CREATED_BY_NDLA","copyright":{"license":"by","creators":[{"name":"henrik","type":"Writer"}],"processors":[],"rightsholders":[]},"title":[{"title":"tittel","language":"nb"}]}"""
+    val expected =
+      s"""{"verificationStatus":"CREATED_BY_NDLA","copyright":{"license":"by","creators":[{"name":"henrik","type":"Writer"}],"processors":[],"rightsholders":[]},"title":[{"title":"tittel","language":"nb"}]}"""
+
+    migration.convertLearningPathDocument(old) should be(expected)
+  }
+
+}


### PR DESCRIPTION
Kan ikke deployes før auth er oppdatert i miljøet og de oppdaterte secret'ene er applya til miljøet.