### PR TITLE
#2226: Only create initial scroll-context when provided with '0', 'start', 'first' or 'initial'

### DIFF
--- a/src/main/scala/no/ndla/learningpathapi/LearningpathApiProperties.scala
+++ b/src/main/scala/no/ndla/learningpathapi/LearningpathApiProperties.scala
@@ -63,7 +63,8 @@ object LearningpathApiProperties extends LazyLogging {
   val UsernameHeader = "X-Consumer-Username"
 
   val ElasticSearchIndexMaxResultWindow = 10000
-  val ElasticSearchScrollKeepAlive = "10s"
+  val ElasticSearchScrollKeepAlive = "1m"
+  val InitialScrollContextKeywords = List("0", "initial", "start", "first")
 
   val BasicHtmlTags = List("b",
                            "blockquote",

--- a/src/main/scala/no/ndla/learningpathapi/model/domain/SearchSettings.scala
+++ b/src/main/scala/no/ndla/learningpathapi/model/domain/SearchSettings.scala
@@ -1,0 +1,15 @@
+package no.ndla.learningpathapi.model.domain
+
+case class SearchSettings(
+    query: Option[String],
+    withIdIn: List[Long],
+    withPaths: List[String],
+    taggedWith: Option[String],
+    searchLanguage: String,
+    sort: Sort.Value,
+    page: Option[Int],
+    pageSize: Option[Int],
+    fallback: Boolean,
+    verificationStatus: Option[String],
+    shouldScroll: Boolean
+)

--- a/src/main/scala/no/ndla/learningpathapi/model/domain/UserInfo.scala
+++ b/src/main/scala/no/ndla/learningpathapi/model/domain/UserInfo.scala
@@ -36,16 +36,13 @@ object UserInfo extends LazyLogging {
   def get: Option[UserInfo] = AuthUser.get.orElse(AuthUser.getClientId).map(UserInfo.apply)
 
   def getWithUserIdOrAdmin = {
-    val failedResponse = Failure(AccessDeniedException("You do not have access to the requested resource."))
-
     AuthUser.get match {
       case Some(userId) => Success(UserInfo(userId))
       case None =>
         this.get match {
           case Some(user) if user.isAdmin => Success(user)
-          case _                          => failedResponse
+          case _                          => Failure(AccessDeniedException("You do not have access to the requested resource."))
         }
-      case None => failedResponse
     }
   }
 }

--- a/src/test/scala/no/ndla/learningpathapi/TestData.scala
+++ b/src/test/scala/no/ndla/learningpathapi/TestData.scala
@@ -11,7 +11,7 @@ import java.util.Date
 
 import no.ndla.mapping.License.CC_BY
 import no.ndla.learningpathapi.model.domain
-import no.ndla.learningpathapi.model.domain.{Language, LearningStep}
+import no.ndla.learningpathapi.model.domain.{Language, LearningStep, SearchSettings, Sort}
 import no.ndla.learningpathapi.model.domain.config.ConfigKey
 import org.joda.time.DateTime
 
@@ -84,6 +84,20 @@ object TestData {
     "me",
     domain.Copyright(CC_BY.toString, List.empty),
     Some(List(domainLearningStep1, domainLearningStep2))
+  )
+
+  val searchSettings = SearchSettings(
+    query = None,
+    withIdIn = List.empty,
+    withPaths = List.empty,
+    taggedWith = None,
+    searchLanguage = Language.DefaultLanguage,
+    sort = Sort.ByIdAsc,
+    page = None,
+    pageSize = None,
+    fallback = false,
+    verificationStatus = None,
+    shouldScroll = false
   )
 
 }

--- a/src/test/scala/no/ndla/learningpathapi/controller/LearningpathControllerV2Test.scala
+++ b/src/test/scala/no/ndla/learningpathapi/controller/LearningpathControllerV2Test.scala
@@ -11,6 +11,7 @@ package no.ndla.learningpathapi.controller
 import java.util.Date
 
 import javax.servlet.http.HttpServletRequest
+import no.ndla.learningpathapi.TestData.searchSettings
 import no.ndla.learningpathapi.model.api
 import no.ndla.learningpathapi.model.api.SearchResultV2
 import no.ndla.learningpathapi.model.domain._
@@ -71,18 +72,18 @@ class LearningpathControllerV2Test extends UnitSuite with TestEnvironment with S
     val apiResult = SearchResultV2(1, Some(1), 1, "nb", Seq(DefaultLearningPathSummary))
     when(searchConverterService.asApiSearchResult(result)).thenReturn(apiResult)
 
-    when(
-      searchService.matchingQuery(
-        eqTo(List(1, 2)),
-        eqTo(query),
-        eqTo(Some(tag)),
-        eqTo(language),
-        eqTo(Sort.ByDurationDesc),
-        eqTo(Some(page)),
-        eqTo(Some(pageSize)),
-        eqTo(false),
-        eqTo(Some(verificationStatus))
-      )).thenReturn(Success(result))
+    val expectedSettings = searchSettings.copy(
+      query = Some(query),
+      withIdIn = List(1, 2),
+      taggedWith = Some(tag),
+      searchLanguage = language,
+      sort = Sort.ByDurationDesc,
+      page = Some(page),
+      pageSize = Some(pageSize),
+      verificationStatus = Some(verificationStatus)
+    )
+
+    when(searchService.matchingQuery(eqTo(expectedSettings))).thenReturn(Success(result))
 
     get(
       "/",
@@ -116,15 +117,7 @@ class LearningpathControllerV2Test extends UnitSuite with TestEnvironment with S
     val apiResult = SearchResultV2(-1, Some(1), 1, "nb", Seq(DefaultLearningPathSummary))
     when(searchConverterService.asApiSearchResult(result)).thenReturn(apiResult)
 
-    when(
-      searchService.allV2(any[List[Long]],
-                          any[Option[String]],
-                          any[Sort.Value],
-                          any[String],
-                          any[Option[Int]],
-                          any[Option[Int]],
-                          eqTo(false),
-                          any[Option[String]])).thenReturn(Success(result))
+    when(searchService.matchingQuery(any[SearchSettings])).thenReturn(Success(result))
 
     get("/",
         Map(
@@ -154,16 +147,17 @@ class LearningpathControllerV2Test extends UnitSuite with TestEnvironment with S
     val apiResult = SearchResultV2(1, Some(page), pageSize, language, Seq(DefaultLearningPathSummary))
     when(searchConverterService.asApiSearchResult(result)).thenReturn(apiResult)
 
-    when(
-      searchService.matchingQuery(eqTo(List(1, 2)),
-                                  eqTo(query),
-                                  eqTo(Some(tag)),
-                                  eqTo(language),
-                                  eqTo(Sort.ByDurationDesc),
-                                  eqTo(Some(page)),
-                                  eqTo(Some(pageSize)),
-                                  eqTo(false),
-                                  eqTo(None))).thenReturn(Success(result))
+    val expectedSettings = searchSettings.copy(
+      withIdIn = List(1, 2),
+      query = Some(query),
+      taggedWith = Some(tag),
+      searchLanguage = language,
+      sort = Sort.ByDurationDesc,
+      page = Some(page),
+      pageSize = Some(pageSize),
+    )
+
+    when(searchService.matchingQuery(eqTo(expectedSettings))).thenReturn(Success(result))
 
     post(
       "/search/",
@@ -268,18 +262,7 @@ class LearningpathControllerV2Test extends UnitSuite with TestEnvironment with S
       Seq.empty,
       Some(scrollId)
     )
-    when(
-      searchService.allV2(
-        any[List[Long]],
-        any[Option[String]],
-        any[Sort.Value],
-        any[String],
-        any[Option[Int]],
-        any[Option[Int]],
-        any[Boolean],
-        any[Option[String]]
-      ))
-      .thenReturn(Success(searchResponse))
+    when(searchService.matchingQuery(any[SearchSettings])).thenReturn(Success(searchResponse))
 
     get(s"/") {
       status should be(200)
@@ -307,27 +290,7 @@ class LearningpathControllerV2Test extends UnitSuite with TestEnvironment with S
       status should be(200)
     }
 
-    verify(searchService, times(0)).allV2(
-      any[List[Long]],
-      any[Option[String]],
-      any[Sort.Value],
-      any[String],
-      any[Option[Int]],
-      any[Option[Int]],
-      any[Boolean],
-      any[Option[String]]
-    )
-    verify(searchService, times(0)).matchingQuery(
-      any[List[Long]],
-      any[String],
-      any[Option[String]],
-      any[String],
-      any[Sort.Value],
-      any[Option[Int]],
-      any[Option[Int]],
-      any[Boolean],
-      any[Option[String]]
-    )
+    verify(searchService, times(0)).matchingQuery(any[SearchSettings])
     verify(searchService, times(1)).scroll(eqTo(scrollId), any[String])
   }
 
@@ -350,27 +313,7 @@ class LearningpathControllerV2Test extends UnitSuite with TestEnvironment with S
       status should be(200)
     }
 
-    verify(searchService, times(0)).allV2(
-      any[List[Long]],
-      any[Option[String]],
-      any[Sort.Value],
-      any[String],
-      any[Option[Int]],
-      any[Option[Int]],
-      any[Boolean],
-      any[Option[String]]
-    )
-    verify(searchService, times(0)).matchingQuery(
-      any[List[Long]],
-      any[String],
-      any[Option[String]],
-      any[String],
-      any[Sort.Value],
-      any[Option[Int]],
-      any[Option[Int]],
-      any[Boolean],
-      any[Option[String]]
-    )
+    verify(searchService, times(0)).matchingQuery(any[SearchSettings])
     verify(searchService, times(1)).scroll(eqTo(scrollId), any[String])
   }
 }

--- a/src/test/scala/no/ndla/learningpathapi/service/search/SearchServiceTest.scala
+++ b/src/test/scala/no/ndla/learningpathapi/service/search/SearchServiceTest.scala
@@ -9,6 +9,7 @@
 package no.ndla.learningpathapi.service.search
 
 import no.ndla.learningpathapi.LearningpathApiProperties.{DefaultPageSize, MaxPageSize}
+import no.ndla.learningpathapi.TestData.searchSettings
 import no.ndla.learningpathapi.integration.{Elastic4sClientFactory, NdlaE4sClient}
 import no.ndla.learningpathapi.model.api
 import no.ndla.learningpathapi.model.domain._
@@ -132,29 +133,25 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
   }
 
   test("all learningpaths should be returned if fallback is enabled in all-search") {
-    val Success(res) =
-      searchService.allV2(List.empty,
-                          None,
-                          Sort.ByIdDesc,
-                          "hurr durr I'm a language",
-                          Some(1),
-                          None,
-                          fallback = true,
-                          None)
+    val Success(res) = searchService.matchingQuery(
+      searchSettings.copy(
+        searchLanguage = "hurr durr I'm a language",
+        page = Some(1),
+        fallback = true,
+        sort = Sort.ByIdDesc,
+      ))
     res.results.length should be(res.totalCount)
     res.totalCount should be(5)
   }
 
   test("no learningpaths should be returned if fallback is disabled with an unsupported language in all-search") {
-    val Success(res) =
-      searchService.allV2(List.empty,
-                          None,
-                          Sort.ByIdDesc,
-                          "hurr durr I'm a language",
-                          Some(1),
-                          None,
-                          fallback = false,
-                          None)
+    val Success(res) = searchService.matchingQuery(
+      searchSettings.copy(
+        searchLanguage = "hurr durr I'm a language",
+        page = Some(1),
+        fallback = false,
+        sort = Sort.ByIdDesc,
+      ))
     res.results.length should be(res.totalCount)
     res.totalCount should be(0)
   }
@@ -182,8 +179,10 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
   }
 
   test("That all learningpaths are returned ordered by title descending") {
-    val Success(searchResult) =
-      searchService.allV2(List(), None, Sort.ByTitleDesc, "nb", None, None, fallback = false, None)
+    val Success(searchResult) = searchService.matchingQuery(
+      searchSettings.copy(
+        sort = Sort.ByTitleDesc,
+      ))
     val hits = searchResult.results
     searchResult.totalCount should be(4)
 
@@ -195,8 +194,10 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
   }
 
   test("That all learningpaths are returned ordered by title ascending") {
-    val Success(searchResult) =
-      searchService.allV2(List(), None, Sort.ByTitleAsc, "nb", None, None, fallback = false, None)
+    val Success(searchResult) = searchService.matchingQuery(
+      searchSettings.copy(
+        sort = Sort.ByTitleAsc,
+      ))
     val hits = searchResult.results
 
     searchResult.totalCount should be(4)
@@ -207,8 +208,10 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
   }
 
   test("That all learningpaths are returned ordered by id descending") {
-    val Success(searchResult) =
-      searchService.allV2(List(), None, Sort.ByIdDesc, "nb", None, None, fallback = false, None)
+    val Success(searchResult) = searchService.matchingQuery(
+      searchSettings.copy(
+        sort = Sort.ByIdDesc,
+      ))
     val hits = searchResult.results
 
     searchResult.totalCount should be(4)
@@ -219,8 +222,11 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
   }
 
   test("That all learningpaths are returned ordered by id ascending") {
-    val Success(searchResult) =
-      searchService.allV2(List(), None, Sort.ByIdAsc, "all", None, None, fallback = false, None)
+    val Success(searchResult) = searchService.matchingQuery(
+      searchSettings.copy(
+        sort = Sort.ByIdAsc,
+        searchLanguage = "all"
+      ))
     val hits = searchResult.results
 
     searchResult.totalCount should be(5)
@@ -232,8 +238,10 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
   }
 
   test("That order by durationDesc orders search result by duration descending") {
-    val Success(searchResult) =
-      searchService.allV2(List(), None, Sort.ByDurationDesc, "nb", None, None, fallback = false, None)
+    val Success(searchResult) = searchService.matchingQuery(
+      searchSettings.copy(
+        sort = Sort.ByDurationDesc,
+      ))
     val hits = searchResult.results
 
     searchResult.totalCount should be(4)
@@ -241,8 +249,10 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
   }
 
   test("That order ByDurationAsc orders search result by duration ascending") {
-    val Success(searchResult) =
-      searchService.allV2(List(), None, Sort.ByDurationAsc, "nb", None, None, fallback = false, None)
+    val Success(searchResult) = searchService.matchingQuery(
+      searchSettings.copy(
+        sort = Sort.ByDurationAsc,
+      ))
     val hits = searchResult.results
 
     searchResult.totalCount should be(4)
@@ -250,8 +260,10 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
   }
 
   test("That order ByLastUpdatedDesc orders search result by last updated date descending") {
-    val Success(searchResult) =
-      searchService.allV2(List(), None, Sort.ByLastUpdatedDesc, "nb", None, None, fallback = false, None)
+    val Success(searchResult) = searchService.matchingQuery(
+      searchSettings.copy(
+        sort = Sort.ByLastUpdatedDesc,
+      ))
     val hits = searchResult.results
 
     searchResult.totalCount should be(4)
@@ -260,8 +272,10 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
   }
 
   test("That order ByLastUpdatedAsc orders search result by last updated date ascending") {
-    val Success(searchResult) =
-      searchService.allV2(List(), None, Sort.ByLastUpdatedAsc, "nb", None, None, fallback = false, None)
+    val Success(searchResult) = searchService.matchingQuery(
+      searchSettings.copy(
+        sort = Sort.ByLastUpdatedAsc,
+      ))
     val hits = searchResult.results
 
     searchResult.totalCount should be(4)
@@ -270,8 +284,12 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
   }
 
   test("That all filtered by id only returns learningpaths with the given ids") {
-    val Success(searchResult) =
-      searchService.allV2(List(1, 2), None, Sort.ByTitleAsc, Language.AllLanguages, None, None, fallback = false, None)
+    val Success(searchResult) = searchService.matchingQuery(
+      searchSettings.copy(
+        withIdIn = List(1, 2),
+        sort = Sort.ByTitleAsc,
+        searchLanguage = Language.AllLanguages
+      ))
     val hits = searchResult.results
 
     searchResult.totalCount should be(2)
@@ -280,22 +298,35 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
   }
 
   test("That searching returns matching documents with unmatching language if fallback is enabled") {
-    val Success(searchResult) =
-      searchService.matchingQuery(List(), "Pingvinen", None, "en", Sort.ByTitleAsc, None, None, fallback = true, None)
+    val Success(searchResult) = searchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("Pingvinen"),
+        sort = Sort.ByTitleAsc,
+        searchLanguage = "en",
+        fallback = true
+      ))
 
     searchResult.totalCount should be(1)
   }
 
   test("That searching returns no matching documents with unmatching language if fallback is disabled ") {
-    val Success(searchResult) =
-      searchService.matchingQuery(List(), "Pingvinen", None, "en", Sort.ByTitleAsc, None, None, fallback = false, None)
+    val Success(searchResult) = searchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("Pingvinen"),
+        sort = Sort.ByTitleAsc,
+        searchLanguage = "en",
+        fallback = false
+      ))
 
     searchResult.totalCount should be(0)
   }
 
   test("That searching only returns documents matching the query") {
-    val Success(searchResult) =
-      searchService.matchingQuery(List(), "heltene", None, "nb", Sort.ByTitleAsc, None, None, fallback = false, None)
+    val Success(searchResult) = searchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("heltene"),
+        sort = Sort.ByTitleAsc,
+      ))
     val hits = searchResult.results
 
     searchResult.totalCount should be(1)
@@ -303,16 +334,13 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
   }
 
   test("That search combined with filter by id only returns documents matching the query with one of the given ids") {
-    val Success(searchResult) =
-      searchService.matchingQuery(List(3),
-                                  "morsom",
-                                  None,
-                                  Language.AllLanguages,
-                                  Sort.ByTitleAsc,
-                                  None,
-                                  None,
-                                  fallback = false,
-                                  None)
+    val Success(searchResult) = searchService.matchingQuery(
+      searchSettings.copy(
+        withIdIn = List(3),
+        query = Some("morsom"),
+        sort = Sort.ByTitleAsc,
+        searchLanguage = Language.AllLanguages
+      ))
     val hits = searchResult.results
 
     searchResult.totalCount should be(1)
@@ -320,8 +348,12 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
   }
 
   test("That searching only returns documents matching the query in the specified language") {
-    val Success(searchResult) =
-      searchService.matchingQuery(List(), "guy", None, "en", Sort.ByTitleAsc, None, None, fallback = false, None)
+    val Success(searchResult) = searchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("guy"),
+        sort = Sort.ByTitleAsc,
+        searchLanguage = "en"
+      ))
     val hits = searchResult.results
 
     searchResult.totalCount should be(1)
@@ -329,8 +361,12 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
   }
 
   test("That filtering on tag only returns documents where the tag is present") {
-    val Success(searchResult) =
-      searchService.allV2(List(), Some("superhelt"), Sort.ByTitleAsc, "nb", None, None, fallback = false, None)
+    val Success(searchResult) = searchService.matchingQuery(
+      searchSettings.copy(
+        sort = Sort.ByTitleAsc,
+        taggedWith = Some("superhelt"),
+        searchLanguage = "nb"
+      ))
     val hits = searchResult.results
 
     searchResult.totalCount should be(2)
@@ -340,16 +376,12 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
 
   test(
     "That filtering on tag combined with search only returns documents where the tag is present and the search matches the query") {
-    val Success(searchResult) =
-      searchService.matchingQuery(List(),
-                                  "heltene",
-                                  Some("kanfly"),
-                                  "nb",
-                                  Sort.ByTitleAsc,
-                                  None,
-                                  None,
-                                  fallback = false,
-                                  None)
+    val Success(searchResult) = searchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("heltene"),
+        taggedWith = Some("kanfly"),
+        sort = Sort.ByTitleAsc,
+      ))
     val hits = searchResult.results
 
     searchResult.totalCount should be(1)
@@ -357,16 +389,11 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
   }
 
   test("That searching and ordering by relevance is returning Donald before Batman when searching for tough weirdos") {
-    val Success(searchResult) =
-      searchService.matchingQuery(List(),
-                                  "tøff rar",
-                                  None,
-                                  "nb",
-                                  Sort.ByRelevanceDesc,
-                                  None,
-                                  None,
-                                  fallback = false,
-                                  None)
+    val Success(searchResult) = searchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("tøff rar"),
+        sort = Sort.ByRelevanceDesc,
+      ))
     val hits = searchResult.results
 
     searchResult.totalCount should be(2)
@@ -376,16 +403,11 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
 
   test(
     "That searching and ordering by relevance is returning Donald before Batman and the penguin when searching for duck, bat and bird") {
-    val Success(searchResult) =
-      searchService.matchingQuery(List(),
-                                  "and flaggermus fugl",
-                                  None,
-                                  "nb",
-                                  Sort.ByRelevanceDesc,
-                                  None,
-                                  None,
-                                  fallback = false,
-                                  None)
+    val Success(searchResult) = searchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("and flaggermus fugl"),
+        sort = Sort.ByRelevanceDesc,
+      ))
     val hits = searchResult.results
 
     searchResult.totalCount should be(3)
@@ -396,15 +418,12 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
 
   test(
     "That searching and ordering by relevance is not returning Penguin when searching for duck, bat and bird, but filtering on kanfly") {
-    val Success(searchResult) = searchService.matchingQuery(List(),
-                                                            "and flaggermus fugl",
-                                                            Some("kanfly"),
-                                                            "nb",
-                                                            Sort.ByRelevanceDesc,
-                                                            None,
-                                                            None,
-                                                            fallback = false,
-                                                            None)
+    val Success(searchResult) = searchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("and flaggermus fugl"),
+        taggedWith = Some("kanfly"),
+        sort = Sort.ByRelevanceDesc
+      ))
     val hits = searchResult.results
 
     searchResult.totalCount should be(2)
@@ -413,16 +432,11 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
   }
 
   test("That a search for flaggremsu returns Donald but not Batman if it is misspelled") {
-    val Success(searchResult) =
-      searchService.matchingQuery(List(),
-                                  "and flaggremsu",
-                                  None,
-                                  "nb",
-                                  Sort.ByRelevanceDesc,
-                                  None,
-                                  None,
-                                  fallback = false,
-                                  None)
+    val Success(searchResult) = searchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("and flaggremsu"),
+        sort = Sort.ByRelevanceDesc
+      ))
     val hits = searchResult.results
 
     searchResult.totalCount should be(1)
@@ -430,42 +444,28 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
   }
 
   test("That searching with logical operators works") {
-    val Success(searchResult1) =
-      searchService.matchingQuery(List(),
-                                  "kjeltring + batman",
-                                  None,
-                                  "nb",
-                                  Sort.ByRelevanceAsc,
-                                  None,
-                                  None,
-                                  fallback = false,
-                                  None)
+    val Success(searchResult1) = searchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("kjeltring + batman"),
+        sort = Sort.ByRelevanceAsc
+      ))
     searchResult1.totalCount should be(0)
 
-    val Success(searchResult2) =
-      searchService.matchingQuery(List(),
-                                  "tøff + morsom + -and",
-                                  None,
-                                  "nb",
-                                  Sort.ByRelevanceAsc,
-                                  None,
-                                  None,
-                                  fallback = false,
-                                  None)
+    val Success(searchResult2) = searchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("tøff + morsom + -and"),
+        sort = Sort.ByRelevanceAsc
+      ))
     val hits2 = searchResult2.results
 
     searchResult2.totalCount should be(1)
     hits2.head.id should be(BatmanId)
 
-    val Success(searchResult3) = searchService.matchingQuery(List(),
-                                                             "tøff | morsom | kjeltring",
-                                                             None,
-                                                             "nb",
-                                                             Sort.ByRelevanceAsc,
-                                                             None,
-                                                             None,
-                                                             fallback = false,
-                                                             None)
+    val Success(searchResult3) = searchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("tøff | morsom | kjeltring"),
+        sort = Sort.ByRelevanceAsc
+      ))
     val hits3 = searchResult3.results
 
     searchResult3.totalCount should be(3)
@@ -475,10 +475,18 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
   }
 
   test("That searching for multiple languages returns result in matched language") {
-    val Success(searchNb) =
-      searchService.matchingQuery(List(), "Urelatert", None, "all", Sort.ByTitleAsc, None, None, fallback = false, None)
-    val Success(searchEn) =
-      searchService.matchingQuery(List(), "Unrelated", None, "all", Sort.ByTitleAsc, None, None, fallback = false, None)
+    val Success(searchNb) = searchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("Urelatert"),
+        searchLanguage = "all",
+        sort = Sort.ByTitleAsc
+      ))
+    val Success(searchEn) = searchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("Unrelated"),
+        searchLanguage = "all",
+        sort = Sort.ByTitleAsc
+      ))
 
     searchEn.totalCount should be(1)
     searchEn.results.head.id should be(UnrelatedId)
@@ -496,7 +504,11 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
   }
 
   test("That searching for all languages returns multiple languages") {
-    val Success(search) = searchService.allV2(List(), None, Sort.ByTitleAsc, "all", None, None, fallback = false, None)
+    val Success(search) = searchService.matchingQuery(
+      searchSettings.copy(
+        sort = Sort.ByTitleAsc,
+        searchLanguage = "all"
+      ))
 
     search.totalCount should be(5)
     search.results.head.id should be(BatmanId)
@@ -509,13 +521,21 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
   }
 
   test("that supportedLanguages are sorted correctly") {
-    val Success(search) =
-      searchService.matchingQuery(List(), "Batman", None, "all", Sort.ByTitleAsc, None, None, fallback = false, None)
+    val Success(search) = searchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("Batman"),
+        sort = Sort.ByTitleAsc,
+        searchLanguage = "all"
+      ))
     search.results.head.supportedLanguages should be(Seq("nb", "en"))
   }
 
   test("That searching with fallback still returns searched language if specified") {
-    val Success(search) = searchService.allV2(List(), None, Sort.ByIdAsc, "en", None, None, fallback = true, None)
+    val Success(search) = searchService.matchingQuery(
+      searchSettings.copy(
+        searchLanguage = "en",
+        fallback = true
+      ))
 
     search.totalCount should be(5)
     search.results.head.id should be(PenguinId)
@@ -532,8 +552,13 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
     val pageSize = 2
     val expectedIds = List(1, 2, 3, 4, 5).sliding(pageSize, pageSize).toList
 
-    val Success(initialSearch) =
-      searchService.allV2(List(), None, Sort.ByIdAsc, "all", None, Some(pageSize), fallback = true, None)
+    val Success(initialSearch) = searchService.matchingQuery(
+      searchSettings.copy(
+        searchLanguage = "all",
+        pageSize = Some(pageSize),
+        fallback = true,
+        shouldScroll = true
+      ))
 
     val Success(scroll1) = searchService.scroll(initialSearch.scrollId.get, "all")
     val Success(scroll2) = searchService.scroll(scroll1.scrollId.get, "all")
@@ -547,16 +572,13 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
 
   test(
     "That search combined with filter by verification status only returns documents matching the query with the given verification status") {
-    val Success(searchResult) =
-      searchService.matchingQuery(List(),
-                                  "flaggermus",
-                                  None,
-                                  Language.AllLanguages,
-                                  Sort.ByTitleAsc,
-                                  None,
-                                  None,
-                                  fallback = false,
-                                  Some("EXTERNAL"))
+    val Success(searchResult) = searchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("flaggermus"),
+        searchLanguage = Language.AllLanguages,
+        verificationStatus = Some("EXTERNAL"),
+        sort = Sort.ByTitleAsc
+      ))
     val hits = searchResult.results
 
     searchResult.totalCount should be(1)
@@ -565,15 +587,12 @@ class SearchServiceTest extends UnitSuite with IntegrationTestEnvironment {
 
   test(
     "That search combined with filter by verification status only returns documents with the given verification status") {
-    val Success(searchResult) =
-      searchService.allV2(List(),
-                          None,
-                          Sort.ByTitleAsc,
-                          Language.AllLanguages,
-                          None,
-                          None,
-                          fallback = false,
-                          Some("CREATED_BY_NDLA"))
+    val Success(searchResult) = searchService.matchingQuery(
+      searchSettings.copy(
+        searchLanguage = Language.AllLanguages,
+        verificationStatus = Some("CREATED_BY_NDLA"),
+        sort = Sort.ByTitleAsc
+      ))
     val hits = searchResult.results
 
     searchResult.totalCount should be(1)


### PR DESCRIPTION
Relates to NDLANO/Issues#2226