### PR TITLE
Only spawn pact suite when running pact tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
         - find $HOME/.sbt -name "*.lock" -delete
 
     - name: "Pact provider verification tests"
-      script: sbt ++$TRAVIS_SCALA_VERSION "pact:testOnly -- -n PactProviderTest"
+      script: sbt ++$TRAVIS_SCALA_VERSION "pact:testOnly *consumerdrivencontracts*"
       env:
           - LEARNINGPATH_CLIENT_ID=""
           - LEARNINGPATH_CLIENT_SECRET=""
@@ -88,4 +88,4 @@ matrix:
 
   allow_failures:
       - name: "Release"
-    
+


### PR DESCRIPTION
Skal forhåpentligvis fikse minneproblemene på travis under pact-testene.

Kjører bare test suiter som heter noe med `*consumerdrivencontracts*` (Som er det pakkenavnet hvor pact-testene ligger).
Da slipper vi å spawne docker-containere (Som bruker masse minne) for alle testsuiter vi hopper over tester i dersom vi bruker tags slik som tidligere.

Grunnen til at det ikke skjer ved vanlig `sbt test` er fordi vi ikke hopper over testene så containere rekker å bli slettet før vi har for mange samtidig til at minnet blir fullt.