### PR TITLE
2494 vise om en artikkel er brukt i læringssti

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "4.0.2")
-addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.4.1")
+addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.8.0")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
 addSbtPlugin("com.itv" % "sbt-scalapact" % "2.3.16")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")

--- a/src/main/scala/no/ndla/learningpathapi/integration/TaxonomyApiClient.scala
+++ b/src/main/scala/no/ndla/learningpathapi/integration/TaxonomyApiClient.scala
@@ -205,6 +205,12 @@ trait TaxonomyApiClient {
       }
     }
 
+    def queryResource(articleId: Long): Try[List[Resource]] =
+      get[List[Resource]](s"$TaxonomyApiEndpoint/queries/resources", "contentURI" -> s"urn:article:$articleId")
+
+    def queryTopic(articleId: Long): Try[List[Topic]] =
+      get[List[Topic]](s"$TaxonomyApiEndpoint/queries/topics", "contentURI" -> s"urn:article:$articleId")
+
     private def get[A](url: String, params: (String, String)*)(implicit mf: Manifest[A]): Try[A] = {
       ndlaClient.fetchWithForwardedAuth[A](Http(url).timeout(taxonomyTimeout, taxonomyTimeout).params(params))
     }
@@ -279,3 +285,17 @@ case class ResourceResourceType(
     resourceId: String,
     resourceTypeId: String
 )
+
+trait Taxonomy[E <: Taxonomy[E]] {
+  val id: String
+  def name: String
+  def withName(name: String): E
+}
+
+case class Resource(id: String, name: String, contentUri: Option[String], paths: List[String])
+    extends Taxonomy[Resource] {
+  def withName(name: String): Resource = this.copy(name = name)
+}
+case class Topic(id: String, name: String, contentUri: Option[String], paths: List[String]) extends Taxonomy[Topic] {
+  def withName(name: String): Topic = this.copy(name = name)
+}

--- a/src/test/scala/no/ndla/learningpathapi/controller/LearningpathControllerV2Test.scala
+++ b/src/test/scala/no/ndla/learningpathapi/controller/LearningpathControllerV2Test.scala
@@ -341,6 +341,13 @@ class LearningpathControllerV2Test extends UnitSuite with TestEnvironment with S
       verify(searchService, times(1)).matchingQuery(expectedSettings)
       verify(searchService, times(0)).scroll(any[String], any[String])
     }
+  }
 
+  test("That GET /contains-article returns 200") {
+    reset(searchService);
+
+    get("/contains-article/123") {
+      status should be(200)
+    }
   }
 }

--- a/src/test/scala/no/ndla/learningpathapi/controller/LearningpathControllerV2Test.scala
+++ b/src/test/scala/no/ndla/learningpathapi/controller/LearningpathControllerV2Test.scala
@@ -11,6 +11,7 @@ package no.ndla.learningpathapi.controller
 import java.util.Date
 import javax.servlet.http.HttpServletRequest
 import no.ndla.learningpathapi.TestData.searchSettings
+import no.ndla.learningpathapi.integration.{Resource, Topic}
 import no.ndla.learningpathapi.model.api
 import no.ndla.learningpathapi.model.api.SearchResultV2
 import no.ndla.learningpathapi.model.domain._
@@ -21,6 +22,7 @@ import org.json4s.DefaultFormats
 import org.json4s.native.Serialization._
 import org.mockito.ArgumentMatchers._
 import org.scalatra.test.scalatest.ScalatraFunSuite
+import scalikejdbc.TxBoundary.Try
 
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success}
@@ -344,10 +346,34 @@ class LearningpathControllerV2Test extends UnitSuite with TestEnvironment with S
   }
 
   test("That GET /contains-article returns 200") {
-    reset(searchService);
+    reset(taxononyApiClient)
+
+    val result = domain.SearchResult(
+      totalCount = 0,
+      page = None,
+      pageSize = 10,
+      language = "all",
+      results = Seq.empty,
+      scrollId = Some("heiheihei")
+    )
+    when(taxononyApiClient.queryResource(any[Long])).thenReturn(Success(List[Resource]()))
+    when(taxononyApiClient.queryTopic(any[Long])).thenReturn(Success(List[Topic]()))
+    when(searchService.containsPath(any[List[String]])).thenReturn(Success(result))
 
     get("/contains-article/123") {
       status should be(200)
+    }
+  }
+
+  test("That GET /contains-article returns correct errors when id is a string or nothing") {
+    reset(taxononyApiClient)
+
+    get("/contains-article/hallohallo") {
+      status should be(400)
+    }
+
+    get("/contains-article/") {
+      status should be(404)
     }
   }
 }


### PR DESCRIPTION
For NDLANO/Issues#2494

Lagt til endepunkt `/contains-article/:article_id`. Har egentlig bare gjort det så og si likt som det som ligger i `InternController`, bortsett fra at jeg bare tar inn id som parameter og lager search-queryen sånn som der det interne endepunktet blir opprettet i`draft-api`. Så vet ikke helt hva av queryen som egentlig trengs, men tok bare med alle variantene. 

Test: F.ex. artikkel `7539` ligger i læringssti `911` i test. Men artikkel `1111` ligger ikke i noen læringssti, så får bare en tom liste i retur. 

Vi snakket vel om at det går an å fjerne den fra `InternController`, og så bare endre hvordan det blir brukt i `draft-api`, men ja jeg vet ikke hva som er best!