### PR TITLE
2536 Contains-article uten DELETED-status

### DIFF
--- a/src/main/scala/no/ndla/learningpathapi/controller/LearningpathControllerV2.scala
+++ b/src/main/scala/no/ndla/learningpathapi/controller/LearningpathControllerV2.scala
@@ -871,21 +871,8 @@ trait LearningpathControllerV2 {
       val paths = resources ++ topics ++ plainPaths
 
       searchService.containsPath(paths) match {
-        case Success(result) =>
-          result.results.filter(learningpath => {
-            readService.withIdV2(learningpath.id, learningpath.title.language, fallback = true) match {
-              case Success(steps) =>
-                steps.learningsteps.exists(step => {
-                  step.embedUrl match {
-                    case Some(embedUrl) =>
-                      embedUrl.url.contains(articleId.toString)
-                    case None => false
-                  }
-                })
-              case Failure(ex) => false
-            }
-          })
-        case Failure(ex) => errorHandler(ex)
+        case Success(result) => result.results
+        case Failure(ex)     => errorHandler(ex)
       }
     }
   }

--- a/src/main/scala/no/ndla/learningpathapi/controller/LearningpathControllerV2.scala
+++ b/src/main/scala/no/ndla/learningpathapi/controller/LearningpathControllerV2.scala
@@ -869,17 +869,14 @@ trait LearningpathControllerV2 {
         s"/article/$articleId"
       )
       val paths = resources ++ topics ++ plainPaths
-      val userInfo = UserInfo.getUserOrPublic
 
       searchService.containsPath(paths) match {
         case Success(result) =>
           result.results.filter(learningpath => {
-            readService.withIdV2(learningpath.id, learningpath.title.language, fallback = true, userInfo) match {
+            readService.withIdV2(learningpath.id, learningpath.title.language, fallback = true) match {
               case Success(steps) =>
-                val r = s".*\\/article.*\\/$articleId.*".r
-                steps.learningsteps.exists(_.embedUrl.get.url match {
-                  case r(_*) => true
-                })
+                steps.learningsteps.exists(_.embedUrl.get.url.contains(articleId))
+              case Failure(ex) => false
             }
           })
         case Failure(ex) => errorHandler(ex)

--- a/src/main/scala/no/ndla/learningpathapi/controller/LearningpathControllerV2.scala
+++ b/src/main/scala/no/ndla/learningpathapi/controller/LearningpathControllerV2.scala
@@ -875,7 +875,13 @@ trait LearningpathControllerV2 {
           result.results.filter(learningpath => {
             readService.withIdV2(learningpath.id, learningpath.title.language, fallback = true) match {
               case Success(steps) =>
-                steps.learningsteps.exists(_.embedUrl.get.url.contains(articleId))
+                steps.learningsteps.exists(step => {
+                  step.embedUrl match {
+                    case Some(embedUrl) =>
+                      embedUrl.url.contains(articleId.toString)
+                    case None => false
+                  }
+                })
               case Failure(ex) => false
             }
           })

--- a/src/main/scala/no/ndla/learningpathapi/model/search/SearchableLearningStep.scala
+++ b/src/main/scala/no/ndla/learningpathapi/model/search/SearchableLearningStep.scala
@@ -10,5 +10,6 @@ package no.ndla.learningpathapi.model.search
 
 case class SearchableLearningStep(stepType: String,
                                   embedUrl: List[String],
+                                  status: String,
                                   titles: SearchableTitles,
                                   descriptions: SearchableDescriptions)

--- a/src/main/scala/no/ndla/learningpathapi/service/search/SearchConverterServiceComponent.scala
+++ b/src/main/scala/no/ndla/learningpathapi/service/search/SearchConverterServiceComponent.scala
@@ -197,6 +197,7 @@ trait SearchConverterServiceComponent {
       SearchableLearningStep(
         learningStep.`type`.toString,
         learningStep.embedUrl.map(_.url).toList,
+        learningStep.status.toString,
         asSearchableTitles(learningStep.title),
         asSearchableDescriptions(learningStep.description)
       )

--- a/src/main/scala/no/ndla/learningpathapi/service/search/SearchIndexService.scala
+++ b/src/main/scala/no/ndla/learningpathapi/service/search/SearchIndexService.scala
@@ -256,6 +256,7 @@ trait SearchIndexService {
         nestedField("learningsteps").fields(
           textField("stepType"),
           keywordField("embedUrl"),
+          keywordField("status"),
           languageSupportedField("titles"),
           languageSupportedField("descriptions")
         ),

--- a/src/main/scala/no/ndla/learningpathapi/service/search/SearchService.scala
+++ b/src/main/scala/no/ndla/learningpathapi/service/search/SearchService.scala
@@ -220,8 +220,14 @@ trait SearchService extends LazyLogging {
       if (paths.isEmpty) None
       else {
         Some(
-          nestedQuery("learningsteps",
-                      boolQuery().should(paths.map(p => wildcardQuery("learningsteps.embedUrl", s"*$p")))))
+          nestedQuery(
+            "learningsteps",
+            boolQuery()
+              .should(paths.map(p => wildcardQuery("learningsteps.embedUrl", s"*$p")))
+              .minimumShouldMatch(1)
+              .filter(matchQuery("learningsteps.status", "ACTIVE"))
+          )
+        )
       }
     }
 

--- a/src/main/scala/no/ndla/learningpathapi/service/search/SearchService.scala
+++ b/src/main/scala/no/ndla/learningpathapi/service/search/SearchService.scala
@@ -224,8 +224,8 @@ trait SearchService extends LazyLogging {
             "learningsteps",
             boolQuery()
               .should(paths.map(p => wildcardQuery("learningsteps.embedUrl", s"*$p")))
+              .must(matchQuery("learningsteps.status", "ACTIVE"))
               .minimumShouldMatch(1)
-              .filter(matchQuery("learningsteps.status", "ACTIVE"))
           )
         )
       }

--- a/src/test/scala/no/ndla/learningpathapi/service/search/SearchConverterServiceTest.scala
+++ b/src/test/scala/no/ndla/learningpathapi/service/search/SearchConverterServiceTest.scala
@@ -173,7 +173,8 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
       None
     )
     val embedUrls = List("https://ndla.no/article/123")
-    val learningStep = SearchableLearningStep("INTRODUCTION", embedUrls, searchableTitles, searchableDescriptions)
+    val learningStep =
+      SearchableLearningStep("INTRODUCTION", embedUrls, "ACTIVE", searchableTitles, searchableDescriptions)
 
     val apiIntroductions = service.asApiIntroduction(Some(learningStep))
     apiIntroductions.size should be(3)
@@ -187,7 +188,8 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
       SearchableTitles(None, None, None, None, None, None, None, None, None)
     val searchableDescriptions = SearchableDescriptions(None, None, None, None, None, None, None, None, None)
     val embedUrls = List("https://ndla.no/article/123")
-    val learningStep = SearchableLearningStep("INTRODUCTION", embedUrls, searchableTitles, searchableDescriptions)
+    val learningStep =
+      SearchableLearningStep("INTRODUCTION", embedUrls, "ACTIVE", searchableTitles, searchableDescriptions)
 
     val apiIntroductions = service.asApiIntroduction(Some(learningStep))
     apiIntroductions.size should be(0)


### PR DESCRIPTION
Fixes NDLANO/Issues#2536

Filtrerer ut de læringsstiene der den gitte artikkelen er i et slettet læringssteg.

Kan teste med:
- Artikkel 5379 er i læringssteg 2614 i læringssti 341 med status DELETED
- Artikkel 5418 er i læringssteg 2618 i samme læringssti som ACTIVE